### PR TITLE
refactor(answer): 기존의 Answer 도메인에 관련된 CRUD 로직을 수정한다

### DIFF
--- a/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
@@ -24,8 +24,8 @@ public class Answer {
     protected Answer() {
     }
 
-    public Answer(AnswerRequestDto answerRequestDto, Long postId, Long userId) {
-        this(null, answerRequestDto.getContent(), LocalDateTime.now(), postId, userId);
+    public Answer(String content, Long postId, Long userId) {
+        this(null, content, LocalDateTime.now(), postId, userId);
     }
 
     public Answer(Long id, String content, LocalDateTime created, Long postId, Long userId) {

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
@@ -15,26 +15,19 @@ public class Answer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String title;
-
-    private String description;
-
-    private String category;
-
+    private String content;
     private String created;
-
+    private Long postId;
     private Long userId;
 
     protected Answer() {
     }
 
-    public Answer(Long id, String title, String description, String category, String created, Long userId) {
+    public Answer(Long id, String content, String created, Long postId, Long userId) {
         this.id = id;
-        this.title = title;
-        this.description = description;
-        this.category = category;
+        this.content = content;
         this.created = created;
+        this.postId = postId;
         this.userId = userId;
     }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
@@ -8,22 +8,27 @@ import javax.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
-@Setter
 public class Answer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
-    private String created;
+    private LocalDateTime created;
     private Long postId;
     private Long userId;
 
     protected Answer() {
     }
 
-    public Answer(Long id, String content, String created, Long postId, Long userId) {
+    public Answer(AnswerRequestDto answerRequestDto, Long postId, Long userId) {
+        this(null, answerRequestDto.getContent(), LocalDateTime.now(), postId, userId);
+    }
+
+    public Answer(Long id, String content, LocalDateTime created, Long postId, Long userId) {
         this.id = id;
         this.content = content;
         this.created = created;

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
@@ -1,12 +1,10 @@
 package com.example.gistcompetitioncnserver.answer;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -34,5 +32,9 @@ public class Answer {
         this.created = created;
         this.postId = postId;
         this.userId = userId;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
     }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -1,17 +1,24 @@
 package com.example.gistcompetitioncnserver.answer;
 
+import com.example.gistcompetitioncnserver.exception.CustomException;
+import com.example.gistcompetitioncnserver.exception.ErrorCase;
 import com.example.gistcompetitioncnserver.post.PostRepository;
+import com.example.gistcompetitioncnserver.post.PostRequestDto;
 import com.example.gistcompetitioncnserver.post.PostService;
+import com.example.gistcompetitioncnserver.user.User;
 import com.example.gistcompetitioncnserver.user.UserService;
 import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/v1/answer") // not used in rest api like v1 url
+@RequestMapping("/v1") // not used in rest api like v1 url
 public class AnswerController {
 
     private final AnswerService answerService;
@@ -19,54 +26,34 @@ public class AnswerController {
     private final UserService userService;
     private final PostRepository postRepository;
 
-//    @PostMapping("/{id}")
-//    public Long createAnswer(@PathVariable Long id, @RequestBody Answer answer){
-//
-//        Optional<User> isEmployee = userDaoService.findUserById(answer.getUserId());
-//        Optional<Post> tobeAnsweredPost = null;
-//        Answer savedAnswer = null;
-//
-//        //현재 글을 작성하는 유저가 직원 타입이  맞는지 확인
-//        //답변 생성 및 답변 된 게시글의 상태를 answer로 변경
-//        //답변의 id를 return
-//        if(isEmployee.get().getUsertype().equals("employee")) {
-//            savedAnswer = answerService.createAnswer(answer, postService.retrievePost(id).get());
-//            postService.updateAnsweredPost(id);
-//            return savedAnswer.getId();
-//        }
-//
-//        return -1L;
+    private boolean isRequestBodyValid(AnswerRequestDto answerRequestDto) {
+        return answerRequestDto.getContent() != null ;
+    }
+    @PostMapping("/posts/{postId}/answer")
+    public ResponseEntity<Object> createAnswer(@PathVariable Long postId, @RequestBody AnswerRequestDto answerRequestDto,
+                                             @AuthenticationPrincipal String email) {
+        User user = userService.findUserByEmail2(email);
+
+        if (!isRequestBodyValid(answerRequestDto)) {
+            throw new CustomException(ErrorCase.INVAILD_FILED_ERROR);
+        }
+
+        return ResponseEntity.created(URI.create("/posts/" + postId + answerService.createAnswer(postId, answerRequestDto, user.getId())))
+                .build();
+    }
+
+    @GetMapping("/posts/{postId}/answer/{answerId}")
+    public Optional<Answer> retrieveAnswer(@PathVariable Long postId,@PathVariable Long answerId){
+        return answerService.retrieveAnswer(answerId);
+    }
+
+
+//    @DeleteMapping("/posts/{postId}/answer/{answerId}")
+//    public void deleteAnswer(@PathVariable Long postId,@PathVariable Long answerId)){
+//        answerService.deleteAnswer(answerId);
 //    }
 
-    @GetMapping("")
-    public List<Answer> retrieveAllPost(){
-        return answerService.retrieveAllAnswers();
-    }
-
-    @GetMapping("/{id}")
-    public Optional<Answer> retrieveAnswer(@PathVariable Long id){
-        return answerService.retrieveAnswer(id);
-    }
-
-    @GetMapping("/count")
-    public Long getPageNumber(){
-        return answerService.getPageNumber();
-    }
-
-    @GetMapping("/category")
-    public List<Answer> getPostsByCategory(@RequestParam("categoryName") String categoryName){
-        return answerService.getAnswersByCategory(categoryName);
-    }
-
-    @DeleteMapping("/{id}")
-    public void deletePost(@PathVariable Long id){
-        answerService.deleteAnswer(id);
-    }
 
 
-//    @PutMapping("/{id}")
-//    public void amendPost(@PathVariable Long id, @RequestBody Post post){
-//        postRepository.
-//    }
 
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -41,6 +41,11 @@ public class AnswerController {
         return ResponseEntity.ok().body(answerService.retrieveAnswerByPostId(postId));
     }
 
+    @GetMapping("/answers/count")
+    public ResponseEntity<Long> getNumberOfAnswers() {
+        return ResponseEntity.ok().body(answerService.getNumberOfAnswers());
+    }
+
     @PutMapping("/posts/{postId}/answer")
     public ResponseEntity<Void> updateAnswer(@PathVariable Long postId
             , AnswerRequestDto changeRequest
@@ -50,9 +55,12 @@ public class AnswerController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/answers/count")
-    public ResponseEntity<Long> getNumberOfAnswers() {
-        return ResponseEntity.ok().body(answerService.getNumberOfAnswers());
-    }
+    @DeleteMapping("/posts/{postId}/answer")
+    public ResponseEntity<Object> deleteComment(@PathVariable Long postId,
+                                                @AuthenticationPrincipal String email) {
+        User user = userService.findUserByEmail2(email);
 
+        answerService.deleteAnswer(user.getId(), postId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -2,9 +2,6 @@ package com.example.gistcompetitioncnserver.answer;
 
 import com.example.gistcompetitioncnserver.exception.CustomException;
 import com.example.gistcompetitioncnserver.exception.ErrorCase;
-import com.example.gistcompetitioncnserver.post.PostRepository;
-import com.example.gistcompetitioncnserver.post.PostRequestDto;
-import com.example.gistcompetitioncnserver.post.PostService;
 import com.example.gistcompetitioncnserver.user.User;
 import com.example.gistcompetitioncnserver.user.UserService;
 import lombok.AllArgsConstructor;
@@ -13,8 +10,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.List;
-import java.util.Optional;
 
 @RestController
 @AllArgsConstructor
@@ -41,9 +36,9 @@ public class AnswerController {
         return answerRequestDto.getContent() != null ;
     }
 
-    @GetMapping("/posts/{postId}/answer/{answerId}")
-    public Optional<Answer> retrieveAnswer(@PathVariable Long postId,@PathVariable Long answerId){
-        return answerService.retrieveAnswer(answerId);
+    @GetMapping("/posts/{postId}/answer")
+    public ResponseEntity<Answer> retrieveAnswer(@PathVariable Long postId){
+        return ResponseEntity.ok().body(answerService.retrieveAnswerByPostId(postId));
     }
 
 

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -41,6 +41,15 @@ public class AnswerController {
         return ResponseEntity.ok().body(answerService.retrieveAnswerByPostId(postId));
     }
 
+    @PutMapping("/posts/{postId}/answer")
+    public ResponseEntity<Void> updateAnswer(@PathVariable Long postId
+            , AnswerRequestDto changeRequest
+            ,@AuthenticationPrincipal String email) {
+        User user = userService.findUserByEmail2(email);
+        answerService.updateAnswer(postId, user.getId(), changeRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/answers/count")
     public ResponseEntity<Long> getNumberOfAnswers() {
         return ResponseEntity.ok().body(answerService.getNumberOfAnswers());

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -13,7 +13,7 @@ import java.net.URI;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/v1") // not used in rest api like v1 url
+@RequestMapping("/v1")
 public class AnswerController {
 
     private final AnswerService answerService;

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -22,13 +22,8 @@ import java.util.Optional;
 public class AnswerController {
 
     private final AnswerService answerService;
-    private final PostService postService;
     private final UserService userService;
-    private final PostRepository postRepository;
 
-    private boolean isRequestBodyValid(AnswerRequestDto answerRequestDto) {
-        return answerRequestDto.getContent() != null ;
-    }
     @PostMapping("/posts/{postId}/answer")
     public ResponseEntity<Object> createAnswer(@PathVariable Long postId, @RequestBody AnswerRequestDto answerRequestDto,
                                              @AuthenticationPrincipal String email) {
@@ -38,8 +33,12 @@ public class AnswerController {
             throw new CustomException(ErrorCase.INVAILD_FILED_ERROR);
         }
 
-        return ResponseEntity.created(URI.create("/posts/" + postId + answerService.createAnswer(postId, answerRequestDto, user.getId())))
-                .build();
+        Long answerId = answerService.createAnswer(postId, answerRequestDto, user.getId());
+        return ResponseEntity.created(URI.create("/posts/" + postId + "/answer/" + answerId)).build();
+    }
+
+    private boolean isRequestBodyValid(AnswerRequestDto answerRequestDto) {
+        return answerRequestDto.getContent() != null ;
     }
 
     @GetMapping("/posts/{postId}/answer/{answerId}")

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerController.java
@@ -41,13 +41,9 @@ public class AnswerController {
         return ResponseEntity.ok().body(answerService.retrieveAnswerByPostId(postId));
     }
 
-
-//    @DeleteMapping("/posts/{postId}/answer/{answerId}")
-//    public void deleteAnswer(@PathVariable Long postId,@PathVariable Long answerId)){
-//        answerService.deleteAnswer(answerId);
-//    }
-
-
-
+    @GetMapping("/answers/count")
+    public ResponseEntity<Long> getNumberOfAnswers() {
+        return ResponseEntity.ok().body(answerService.getNumberOfAnswers());
+    }
 
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findByPostId(Long postId);
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByUserId(Long userId);
-    List<Answer> findByCategory(String categoryName);
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRepository.java
@@ -3,9 +3,9 @@ package com.example.gistcompetitioncnserver.answer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    List<Answer> findByUserId(Long userId);
+    Optional<Answer> findByPostId(Long postId);
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRequestDto.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.gistcompetitioncnserver.answer;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AnswerRequestDto {
+    private String content;
+
+    public AnswerRequestDto(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -1,6 +1,5 @@
 package com.example.gistcompetitioncnserver.answer;
 
-import com.example.gistcompetitioncnserver.comment.Comment;
 import com.example.gistcompetitioncnserver.exception.CustomException;
 import com.example.gistcompetitioncnserver.post.Post;
 import com.example.gistcompetitioncnserver.post.PostRepository;
@@ -28,7 +27,7 @@ public class AnswerService {
     @Transactional
     public Long createAnswer(Long postId, AnswerRequestDto answerRequestDto, Long userId) {
         User user = findUserById(userId);
-        if (user.getUserRole() != UserRole.MANAGER){
+        if (user.getUserRole() != UserRole.MANAGER && user.getUserRole() != UserRole.ADMIN){
             throw new CustomException("답변권한이 없는 user입니다.");
         }
         Post post = postRepository.findById(postId).orElseThrow(()-> new CustomException("존재하지 않는 post입니다"));
@@ -65,7 +64,7 @@ public class AnswerService {
 
     private boolean canUpdate(User user, Answer answer) {
         Long answerOwner = answer.getUserId();
-        return answerOwner.equals(user.getId()) && user.getUserRole()==UserRole.MANAGER;
+        return user.getUserRole() == UserRole.ADMIN || (answerOwner.equals(user.getId()) && user.getUserRole()==UserRole.MANAGER);
     }
 
     @Transactional
@@ -82,7 +81,7 @@ public class AnswerService {
 
     private boolean canDelete(User user, Answer answer) {
         Long answerOwner = answer.getUserId();
-        return user.getUserRole()==UserRole.ADMIN || answerOwner.equals(user.getId()) && user.getUserRole()==UserRole.MANAGER;
+        return user.getUserRole()==UserRole.ADMIN || (answerOwner.equals(user.getId()) && user.getUserRole()==UserRole.MANAGER);
     }
 
 

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -9,7 +9,7 @@ import com.example.gistcompetitioncnserver.user.UserRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
-import java.util.Optional
+import java.util.Optional;
 
 @Service
 public class AnswerService {

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -1,27 +1,44 @@
 package com.example.gistcompetitioncnserver.answer;
 
-
+import com.example.gistcompetitioncnserver.exception.CustomException;
 import com.example.gistcompetitioncnserver.post.Post;
-import lombok.AllArgsConstructor;
+import com.example.gistcompetitioncnserver.post.PostRepository;
+import com.example.gistcompetitioncnserver.user.User;
+import com.example.gistcompetitioncnserver.user.UserRepository;
+import com.example.gistcompetitioncnserver.user.UserRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
 @Service
-@AllArgsConstructor
 public class AnswerService {
 
     private final AnswerRepository answerRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
+    public AnswerService (AnswerRepository answerRepository,
+                          PostRepository postRepository,
+                          UserRepository userRepository) {
+        this.answerRepository = answerRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
 
     @Transactional
     public Long createAnswer(Long postId, AnswerRequestDto answerRequestDto, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(()-> new CustomException("존재하지 않는 user입니다"));
+        if (user.getUserRole() != UserRole.MANAGER){
+            throw new CustomException("답변권한이 없는 user입니다.");
+        }
+        Post post = postRepository.findById(postId).orElseThrow(()-> new CustomException("존재하지 않는 post입니다"));
+        if (post.isAnswered()){
+            throw new CustomException("이미 답변이 된 post입니다.");
+        }
+
         Answer answer = new Answer(answerRequestDto, postId, userId);
-        // TODO answer 검증하기
+        post.setAnswered(true);
         return answerRepository.save(answer).getId();
     }
 

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -1,5 +1,6 @@
 package com.example.gistcompetitioncnserver.answer;
 
+import com.example.gistcompetitioncnserver.comment.Comment;
 import com.example.gistcompetitioncnserver.exception.CustomException;
 import com.example.gistcompetitioncnserver.post.Post;
 import com.example.gistcompetitioncnserver.post.PostRepository;
@@ -68,8 +69,20 @@ public class AnswerService {
     }
 
     @Transactional
-    public void deleteAnswer(Long id){
-        answerRepository.deleteById(id);
+    public void deleteAnswer(Long eraserId, Long postId) {
+        checkExistenceByPostId(postId);
+        Answer answer = findAnswerByPostId(postId);
+
+        User eraser = findUserById(eraserId);
+        if (!canDelete(eraser, answer)) {
+            throw new CustomException("지울 수 있는 권한이 없습니다");
+        }
+        answerRepository.deleteByPostId(postId);
+    }
+
+    private boolean canDelete(User user, Answer answer) {
+        Long answerOwner = answer.getUserId();
+        return user.getUserRole()==UserRole.ADMIN || answerOwner.equals(user.getId()) && user.getUserRole()==UserRole.MANAGER;
     }
 
 

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -37,7 +37,7 @@ public class AnswerService {
             throw new CustomException("이미 답변이 된 post입니다.");
         }
 
-        Answer answer = new Answer(answerRequestDto, postId, userId);
+        Answer answer = new Answer(answerRequestDto.getContent(), postId, userId);
         post.setAnswered(true);
         return answerRepository.save(answer).getId();
     }

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -8,8 +8,6 @@ import com.example.gistcompetitioncnserver.user.UserRepository;
 import com.example.gistcompetitioncnserver.user.UserRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 public class AnswerService {
@@ -42,16 +40,15 @@ public class AnswerService {
         return answerRepository.save(answer).getId();
     }
 
-    public List<Answer> retrieveAllAnswers(){
-        return answerRepository.findAll();
-    }
+    @Transactional(readOnly = true)
+    public Answer retrieveAnswerByPostId(Long postId) throws CustomException{
+        if (!postRepository.existsById(postId)) {
+            throw new CustomException("존재하지 않는 post입니다");
+        }
 
-    public List<Answer> retrieveAnswersByUserId(Long user_id){
-        return answerRepository.findByUserId(user_id);
-    }
-
-    public Optional<Answer> retrieveAnswer(Long id){
-        return answerRepository.findById(id);
+        return answerRepository.findByPostId(postId).orElseThrow(
+                () -> new CustomException("해당 post에는 답변이 존재하지 않습니다.")
+        );
     }
 
     public Long getNumberOfAnswers(){

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -18,11 +18,11 @@ public class AnswerService {
     private final AnswerRepository answerRepository;
 
 
-    public Answer createAnswer(Answer answer, Post post){
-        answer.setCreated(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        answer.setCategory(post.getCategory());
-        answer.setTitle("RE:"+post.getTitle());
-        return answerRepository.save(answer);
+    @Transactional
+    public Long createAnswer(Long postId, AnswerRequestDto answerRequestDto, Long userId) {
+        Answer answer = new Answer(answerRequestDto, postId, userId);
+        // TODO answer 검증하기
+        return answerRepository.save(answer).getId();
     }
 
     public List<Answer> retrieveAllAnswers(){
@@ -37,12 +37,8 @@ public class AnswerService {
         return answerRepository.findById(id);
     }
 
-    public Long getPageNumber(){
+    public Long getNumberOfAnswers(){
         return answerRepository.count();
-    }
-
-    public List<Answer> getAnswersByCategory(String categoryName){
-        return answerRepository.findByCategory(categoryName);
     }
 
     @Transactional

--- a/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/AnswerService.java
@@ -41,7 +41,7 @@ public class AnswerService {
     }
 
     @Transactional(readOnly = true)
-    public Answer retrieveAnswerByPostId(Long postId) throws CustomException{
+    public Answer retrieveAnswerByPostId(Long postId){
         if (!postRepository.existsById(postId)) {
             throw new CustomException("존재하지 않는 post입니다");
         }

--- a/src/main/java/com/example/gistcompetitioncnserver/post/PostController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/post/PostController.java
@@ -20,11 +20,6 @@ public class PostController {
     private final PostService postService;
     private final UserService userService;
 
-    private boolean isRequestBodyValid(PostRequestDto postRequestDto) {
-        return postRequestDto.getTitle() != null &&
-                postRequestDto.getDescription() != null &&
-                postRequestDto.getCategory() != null;
-    }
 
     @PostMapping("/posts")
     public ResponseEntity<Object> createPost(@RequestBody PostRequestDto postRequestDto,
@@ -37,6 +32,12 @@ public class PostController {
 
         return ResponseEntity.created(URI.create("/posts/" + postService.createPost(postRequestDto, user.getId())))
                 .build();
+    }
+
+    private boolean isRequestBodyValid(PostRequestDto postRequestDto) {
+        return postRequestDto.getTitle() != null &&
+                postRequestDto.getDescription() != null &&
+                postRequestDto.getCategory() != null;
     }
 
     @GetMapping("/posts")

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserRole.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserRole.java
@@ -2,5 +2,6 @@ package com.example.gistcompetitioncnserver.user;
 
 public enum UserRole {
     ADMIN,
+    MANAGER,
     USER
 }

--- a/src/test/java/com/example/gistcompetitioncnserver/answer/AnswerServiceTest.java
+++ b/src/test/java/com/example/gistcompetitioncnserver/answer/AnswerServiceTest.java
@@ -89,6 +89,32 @@ class AnswerServiceTest {
         ).isInstanceOf(CustomException.class);
     }
 
+    @Test
+    void retrieveAnswer(){
+        Answer answer= new Answer(CONTENT,postId,managerUserId);
+        answerRepository.save(answer);
+        Answer retrievedAnswer = answerService.retrieveAnswerByPostId(postId);
+        assertThat(answer.getId()).isEqualTo(retrievedAnswer.getId());
+    }
+
+    @Test
+    void retrieveAnswerWithNoAnswer(){
+        assertThatThrownBy(
+                () -> answerService.retrieveAnswerByPostId(postId)
+        ).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void retrieveAnswerByNonExistentPost(){
+        Answer answer= new Answer(CONTENT,postId,managerUserId);
+        answerRepository.save(answer);
+
+        Long fakePostId = Long.MAX_VALUE;
+        assertThatThrownBy(
+                () -> answerService.retrieveAnswerByPostId(fakePostId)
+        ).isInstanceOf(CustomException.class);
+    }
+
     @AfterEach
     void tearDown() {
         userRepository.deleteAllInBatch();


### PR DESCRIPTION
answer entity, controller, service에 대한 리팩토링을 진행했습니다.
진행 주요 내용
1. answer가 postId를 가지고 있는 구조로 만들었습니다.(comment와 같은 구조입니다)
2. answerRequestDto를 만들었습니다.
3. 답변을 카테고리 별로 조회하는 기능은 삭제하였습니다. (현재 answer가 post에 의존하기 때문에 post에만 카테고리 분류기능이 있으면 될 것으로 생각했습니다.)
남은 작업 AnswerService에서 createAnswer할떄 answer에 대해 검증하는 부분이 필요합니다.