### PR TITLE
feat: User 권한 정책 구현

### DIFF
--- a/src/main/java/com/example/gistcompetitioncnserver/user/DeleteUserRequest.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/DeleteUserRequest.java
@@ -1,0 +1,19 @@
+package com.example.gistcompetitioncnserver.user;
+
+import javax.validation.constraints.NotBlank;
+
+public class DeleteUserRequest {
+    @NotBlank
+    private String password;
+
+    public DeleteUserRequest() {
+    }
+
+    public DeleteUserRequest(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/user/SessionUser.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/SessionUser.java
@@ -15,4 +15,8 @@ public class SessionUser implements Serializable {
         this.userRole = user.getUserRole();
         this.enabled = user.isEnabled();
     }
+
+    public boolean isAdmin() {
+        return userRole == UserRole.ADMIN;
+    }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/SignUpRequest.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/SignUpRequest.java
@@ -1,7 +1,12 @@
 package com.example.gistcompetitioncnserver.user;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
 public class SignUpRequest {
+    @Email
     private String username;
+    @NotBlank
     private String password;
 
     public SignUpRequest(String username, String password) {

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UpdatePasswordRequest.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UpdatePasswordRequest.java
@@ -1,0 +1,26 @@
+package com.example.gistcompetitioncnserver.user;
+
+import javax.validation.constraints.NotBlank;
+
+public class UpdatePasswordRequest {
+    @NotBlank
+    private String originPassword;
+    @NotBlank
+    private String newPassword;
+
+    public UpdatePasswordRequest() {
+    }
+
+    public UpdatePasswordRequest(String originPassword, String newPassword) {
+        this.originPassword = originPassword;
+        this.newPassword = newPassword;
+    }
+
+    public String getOriginPassword() {
+        return originPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UpdateUserRoleRequest.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UpdateUserRoleRequest.java
@@ -1,0 +1,19 @@
+package com.example.gistcompetitioncnserver.user;
+
+import javax.validation.constraints.NotNull;
+
+public class UpdateUserRoleRequest {
+    @NotNull
+    private String userRole;
+
+    public UpdateUserRoleRequest() {
+    }
+
+    public UpdateUserRoleRequest(String userRole) {
+        this.userRole = userRole;
+    }
+
+    public String getUserRole() {
+        return userRole;
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/user/User.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/User.java
@@ -52,11 +52,15 @@ public class User {
         return enabled;
     }
 
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     public void setUserRole(UserRole userRole) {
         this.userRole = userRole;
     }
 
-    public void setEnabled(){
+    public void setEnabled() {
         this.enabled = true;
     }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/User.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/User.java
@@ -32,14 +32,6 @@ public class User {
         this.enabled = enabled;
     }
 
-    public boolean isAdmin() {
-        return this.userRole == UserRole.ADMIN;
-    }
-
-    public boolean isManager() {
-        return this.userRole == UserRole.MANAGER;
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -79,7 +79,20 @@ public class UserController {
         if (!sessionUser.getEnabled()) {
             throw new CustomException("이메일 인증이 필요합니다!");
         }
+        if (!sessionUser.isAdmin()) {
+            throw new CustomException("삭제할 권한이 없습니다.");
+        }
         userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/users/me")
+    public ResponseEntity<Void> deleteUserOfMine() {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        userService.deleteUser(sessionUser.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -64,6 +64,15 @@ public class UserController {
         return ResponseEntity.ok().body(userService.findUserById(userId));
     }
 
+    @GetMapping("/users/me")
+    public ResponseEntity<User> retrieveUserOfMine() {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        return ResponseEntity.ok().body(userService.findUserById(sessionUser.getId()));
+    }
+
     @DeleteMapping("/users/{userId}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long userId) {
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
     }
 
     @GetMapping("/users")
-    public ResponseEntity<List<User>> retrieveAllUsers()     {
+    public ResponseEntity<List<User>> retrieveAllUsers() {
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
         if (!sessionUser.getEnabled()) {
             throw new CustomException("이메일 인증이 필요합니다!");
@@ -71,6 +71,16 @@ public class UserController {
             throw new CustomException("이메일 인증이 필요합니다!");
         }
         return ResponseEntity.ok().body(userService.findUserById(sessionUser.getId()));
+    }
+
+    @PutMapping("/users/me/password")
+    public ResponseEntity<Void> updatePasswordOfMine(@Validated @RequestBody UpdatePasswordRequest passwordRequest) {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        userService.updatePassword(sessionUser.getId(), passwordRequest);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/users/{userId}")

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -1,5 +1,6 @@
 package com.example.gistcompetitioncnserver.user;
 
+import com.example.gistcompetitioncnserver.exception.CustomException;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
@@ -40,17 +41,35 @@ public class UserController {
     }
 
     @GetMapping("/users")
-    public ResponseEntity<List<User>> retrieveAllUsers() {
+    public ResponseEntity<List<User>> retrieveAllUsers()     {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        if (!sessionUser.isAdmin()) {
+            throw new CustomException("회원 정보 조회 권한이 없습니다.");
+        }
         return ResponseEntity.ok().body(userService.findAllUsers());
     }
 
     @GetMapping("/users/{userId}")
     public ResponseEntity<User> retrieveUser(@PathVariable Long userId) {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        if (!sessionUser.isAdmin()) {
+            throw new CustomException("회원 정보 조회 권한이 없습니다.");
+        }
         return ResponseEntity.ok().body(userService.findUserById(userId));
     }
 
     @DeleteMapping("/users/{userId}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long userId) {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
         userService.deleteUser(userId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -73,6 +73,20 @@ public class UserController {
         return ResponseEntity.ok().body(userService.findUserById(sessionUser.getId()));
     }
 
+    @PutMapping("/users/{userId}/userRole")
+    public ResponseEntity<Void> updateUserRole(@PathVariable Long userId,
+                                               @Validated @RequestBody UpdateUserRoleRequest userRoleRequest) {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        if (!sessionUser.getEnabled()) {
+            throw new CustomException("이메일 인증이 필요합니다!");
+        }
+        if (!sessionUser.isAdmin()) {
+            throw new CustomException("유저 권한을 수정할 권한이 없습니다.");
+        }
+        userService.updateUserRole(userId, userRoleRequest);
+        return ResponseEntity.noContent().build();
+    }
+
     @PutMapping("/users/me/password")
     public ResponseEntity<Void> updatePasswordOfMine(@Validated @RequestBody UpdatePasswordRequest passwordRequest) {
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserController.java
@@ -111,12 +111,12 @@ public class UserController {
     }
 
     @DeleteMapping("/users/me")
-    public ResponseEntity<Void> deleteUserOfMine() {
+    public ResponseEntity<Void> deleteUserOfMine(@Validated @RequestBody DeleteUserRequest deleteUserRequest) {
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
         if (!sessionUser.getEnabled()) {
             throw new CustomException("이메일 인증이 필요합니다!");
         }
-        userService.deleteUser(sessionUser.getId());
+        userService.deleteUserOfMine(sessionUser.getId(), deleteUserRequest);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserRole.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserRole.java
@@ -1,7 +1,19 @@
 package com.example.gistcompetitioncnserver.user;
 
+import com.example.gistcompetitioncnserver.exception.CustomException;
+
+import java.util.Locale;
+
 public enum UserRole {
     ADMIN,
     MANAGER,
-    USER
+    USER;
+
+    public static UserRole ignoringCaseValueOf(String name) {
+        try {
+            return valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new CustomException("존재하지 않는 유저 권한입니다.");
+        }
+    }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
@@ -65,6 +65,15 @@ public class UserService {
     }
 
     @Transactional
+    public void updatePassword(Long userId, UpdatePasswordRequest passwordRequest) {
+        User user = findUserById(userId);
+        if (!encryptor.isMatch(passwordRequest.getOriginPassword(), user.getPassword())) {
+            throw new CustomException("기존 패쓰워드가 일치하지 않습니다.");
+        }
+        user.setPassword(encryptor.hashPassword(passwordRequest.getNewPassword()));
+    }
+
+    @Transactional
     public void deleteUser(Long userId) {
         if (!userRepository.existsById(userId)) {
             throw new CustomException("존재하지 않는 유저입니다");

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
@@ -86,4 +86,13 @@ public class UserService {
         }
         userRepository.deleteById(userId);
     }
+
+    @Transactional
+    public void deleteUserOfMine(Long userId, DeleteUserRequest deleteUserRequest) {
+        User user = findUserById(userId);
+        if (!encryptor.isMatch(deleteUserRequest.getPassword(), user.getPassword())) {
+            throw new CustomException("기존 패쓰워드가 일치하지 않습니다.");
+        }
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/user/UserService.java
@@ -65,6 +65,12 @@ public class UserService {
     }
 
     @Transactional
+    public void updateUserRole(Long userId, UpdateUserRoleRequest userRoleRequest) {
+        User user = findUserById(userId);
+        user.setUserRole(UserRole.ignoringCaseValueOf(userRoleRequest.getUserRole()));
+    }
+
+    @Transactional
     public void updatePassword(Long userId, UpdatePasswordRequest passwordRequest) {
         User user = findUserById(userId);
         if (!encryptor.isMatch(passwordRequest.getOriginPassword(), user.getPassword())) {

--- a/src/test/java/com/example/gistcompetitioncnserver/user/UserServiceTest.java
+++ b/src/test/java/com/example/gistcompetitioncnserver/user/UserServiceTest.java
@@ -166,6 +166,27 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.deleteUser(notExistedId)).isInstanceOf(CustomException.class);
     }
 
+
+    @Test
+    void deleteUserOfMine() {
+        SignUpRequest signUpRequest = new SignUpRequest(GIST_EMAIL, PASSWORD);
+        Long userId = userService.signUp(signUpRequest);
+
+        userService.deleteUserOfMine(userId, new DeleteUserRequest(signUpRequest.getPassword()));
+
+        assertFalse(userRepository.existsById(userId));
+    }
+
+    @Test
+    void deleteUserOfMineWithInvalidPassword() {
+        SignUpRequest signUpRequest = new SignUpRequest(GIST_EMAIL, PASSWORD);
+        Long userId = userService.signUp(signUpRequest);
+
+        assertThatThrownBy(
+                () -> userService.deleteUserOfMine(userId, new DeleteUserRequest("notPassword"))
+        ).isInstanceOf(CustomException.class);
+    }
+
     @AfterEach
     void tearDown() {
         verificationTokenRepository.deleteAllInBatch();

--- a/src/test/java/com/example/gistcompetitioncnserver/user/UserServiceTest.java
+++ b/src/test/java/com/example/gistcompetitioncnserver/user/UserServiceTest.java
@@ -99,8 +99,34 @@ class UserServiceTest {
         assertThat(httpSession.getAttribute("user")).isNull();
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"manager", "Manager", "MANAGER"})
+    void updateUserRoleToManager(String inputUserRole) {
+        SignUpRequest signUpRequest = new SignUpRequest(GIST_EMAIL, PASSWORD);
+        Long userId = userService.signUp(signUpRequest);
+
+        UpdateUserRoleRequest userRoleRequest = new UpdateUserRoleRequest(inputUserRole);
+        userService.updateUserRole(userId, userRoleRequest);
+
+        User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+        assertThat(user.getUserRole()).isEqualTo(UserRole.MANAGER);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"admin", "Admin", "ADMIN"})
+    void updateUserRoleToAdmin(String inputUserRole) {
+        SignUpRequest signUpRequest = new SignUpRequest(GIST_EMAIL, PASSWORD);
+        Long userId = userService.signUp(signUpRequest);
+
+        UpdateUserRoleRequest userRoleRequest = new UpdateUserRoleRequest(inputUserRole);
+        userService.updateUserRole(userId, userRoleRequest);
+
+        User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+        assertThat(user.getUserRole()).isEqualTo(UserRole.ADMIN);
+    }
+
     @Test
-    void updateUserPassowrd() {
+    void updateUserPassword() {
         SignUpRequest signUpRequest = new SignUpRequest(GIST_EMAIL, PASSWORD);
         Long userId = userService.signUp(signUpRequest);
 


### PR DESCRIPTION
권한 정책을 적용하다 보니 admin과 user에 따라 api를 별도로 분리해줘야 한다 생각헀고, api가 많아졌네요. 권한에 대해 간단히 정리하면 다음과 같습니다.

1. 회원 조회
기본적으로 admin 권한 필요. 본인의 정보에 경우 본인만 조회 가능
2. 회원 정보 수정
userRole 수정 -> admin 권한 필요
password 수정 -> 본인만 가능. (만약, password를 잃어버린 사용자가 나타났을 때를 위해 admin에게 권한을 줘야하나? -> 오히려 패쓰워드 찾기와 같은 api를 별도로 만들어 주도록 하자)
3. 회원 정보 삭제
admin은 삭제 가능
본인의 경우 삭제 가능

회원 본인의 경우 password 수정 및 회원 삭제가 가능한데, 이 때 password를 한번 더 요구하도록 구현해봤습니다.
과정은 아래 이슈를 참고해주세요

Close #98 