### PR TITLE
refactor: post,answer,comment의 작성 내용의 저장 타입을 clob으로 수정

### DIFF
--- a/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/Answer.java
@@ -3,10 +3,7 @@ package com.example.gistcompetitioncnserver.answer;
 import com.example.gistcompetitioncnserver.common.BaseEntity;
 import lombok.Getter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -14,6 +11,7 @@ public class Answer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Lob
     private String content;
     private Long postId;
     private Long userId;

--- a/src/main/java/com/example/gistcompetitioncnserver/comment/Comment.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/comment/Comment.java
@@ -3,10 +3,7 @@ package com.example.gistcompetitioncnserver.comment;
 import com.example.gistcompetitioncnserver.common.BaseEntity;
 import lombok.Getter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @Entity
@@ -14,6 +11,7 @@ public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Lob
     private String content;
     private Long postId;
     private Long userId;

--- a/src/main/java/com/example/gistcompetitioncnserver/post/Post.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/post/Post.java
@@ -18,6 +18,7 @@ public class Post extends BaseEntity {
     @GeneratedValue
     private Long id;
     private String title;
+    @Lob
     private String description;
     private String category;
     private boolean answered;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,19 @@ spring:
   config:
     activate:
       on-profile: dev
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://dev-api.gist-petition.com:3306/dev_petitiondb?serverTimezone=Asia/Seoul
+    username: ${USER_NAME}
+    password: ${PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    properties:
+      hibernate:
+        format_sql: true
 swagger:
   host: dev-api.gist-petition.com
   protocol: http

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,25 +18,6 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-
----
-spring:
-  config:
-    activate:
-      on-profile: dev
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://dev-api.gist-petition.com:3306/dev_petitiondb?serverTimezone=Asia/Seoul
-    username: ${USER_NAME}
-    password: ${PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
-    properties:
-      hibernate:
-        format_sql: true
 swagger:
   host: dev-api.gist-petition.com
   protocol: http


### PR DESCRIPTION
@lob
private String description;
@lob 을 붙여주면 스프링이 알아서 해당 필드가 String,char 타입인 경우에는 Clob으로, 이외에는 Blob으로 binding하여 저장해준다고 합니다.

create Post 테스트를 돌려봤는데
2022-01-08 21:33:20.859 TRACE 17462 --- [ Test worker] o.h.type.descriptor.sql.BasicBinder : binding parameter [6] as [CLOB] - [description]

와 같이 잘 동작함을 확인하였습니다.