### PR TITLE
feat: Error메시지 payload를 json 형식으로 수정한다.

### DIFF
--- a/src/main/java/com/example/gistcompetitioncnserver/exception/ControllerAdvice.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/exception/ControllerAdvice.java
@@ -9,16 +9,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ControllerAdvice {
 
     @ExceptionHandler(ApplicationException.class)
-    public ResponseEntity<String> handle(ApplicationException ex) {
+    public ResponseEntity<ErrorResponse> handle(ApplicationException ex) {
         if (ex instanceof WrappedException) {
-            return ResponseEntity.status(ex.getHttpStatus()).body(ex.getCause().getMessage());
+            return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getCause().getMessage()));
         }
-        return ResponseEntity.status(ex.getHttpStatus()).body(ex.getMessage());
+        return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> validException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ErrorResponse> validException(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-        return ResponseEntity.badRequest().body(message);
+        return ResponseEntity.badRequest().body(new ErrorResponse(message));
     }
+
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/exception/ControllerAdvice.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/exception/ControllerAdvice.java
@@ -10,10 +10,12 @@ public class ControllerAdvice {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> handle(ApplicationException ex) {
-        if (ex instanceof WrappedException) {
-            return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getCause().getMessage()));
-        }
         return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(WrappedException.class)
+    public ResponseEntity<ErrorResponse> handle(WrappedException ex) {
+        return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getCause().getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -21,5 +23,4 @@ public class ControllerAdvice {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity.badRequest().body(new ErrorResponse(message));
     }
-
 }

--- a/src/main/java/com/example/gistcompetitioncnserver/exception/ErrorResponse.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.example.gistcompetitioncnserver.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+public class ErrorResponse {
+    private String message;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
WrappedException의 경우 ExceptionHandler의 분리를 할 수 있을 것 같아, 함께 진행했습니다.

참고) exceptionHandler는 그 계층 구조에서 가장 가까운 핸들러를 택한다고 합니다.

Close #116 