### PR TITLE
refactor: Post 삭제 시 이벤트 방식으로 댓글, 답변 삭제

### DIFF
--- a/src/main/java/com/example/gistcompetitioncnserver/answer/PostDeleteEventListenerOfAnswer.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/answer/PostDeleteEventListenerOfAnswer.java
@@ -1,0 +1,19 @@
+package com.example.gistcompetitioncnserver.answer;
+
+import com.example.gistcompetitioncnserver.post.PostDeleteEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostDeleteEventListenerOfAnswer implements ApplicationListener<PostDeleteEvent> {
+    private final AnswerRepository answerRepository;
+
+    public PostDeleteEventListenerOfAnswer(AnswerRepository answerRepository) {
+        this.answerRepository = answerRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(PostDeleteEvent event) {
+        answerRepository.deleteByPostId(event.getPostId());
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/comment/PostDeleteEventListenerOfComment.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/comment/PostDeleteEventListenerOfComment.java
@@ -1,0 +1,19 @@
+package com.example.gistcompetitioncnserver.comment;
+
+import com.example.gistcompetitioncnserver.post.PostDeleteEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostDeleteEventListenerOfComment implements ApplicationListener<PostDeleteEvent> {
+    private final CommentRepository commentRepository;
+
+    public PostDeleteEventListenerOfComment(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(PostDeleteEvent event) {
+        commentRepository.deleteByPostId(event.getPostId());
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/post/PostController.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/post/PostController.java
@@ -48,8 +48,8 @@ public class PostController {
     }
 
     @GetMapping("/posts/count")
-    public ResponseEntity<Long> getPageNumber() {
-        return ResponseEntity.ok().body(postService.getPageNumber());
+    public ResponseEntity<Long> getPostCount() {
+        return ResponseEntity.ok().body(postService.getPostCount());
     }
 
     @GetMapping("/posts/category")

--- a/src/main/java/com/example/gistcompetitioncnserver/post/PostDeleteEvent.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/post/PostDeleteEvent.java
@@ -1,0 +1,14 @@
+package com.example.gistcompetitioncnserver.post;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class PostDeleteEvent extends ApplicationEvent {
+    private final Long postId;
+
+    public PostDeleteEvent(Long postId) {
+        super(postId);
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/example/gistcompetitioncnserver/post/PostService.java
+++ b/src/main/java/com/example/gistcompetitioncnserver/post/PostService.java
@@ -47,7 +47,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Long getPageNumber() {
+    public Long getPostCount() {
         return postRepository.count();
     }
 


### PR DESCRIPTION
(댓글, 답변 -> 청원) 의존성이 흐를 수 밖에 없는 상황. 패키지를 분리했을 때, 반대의 의존성을 피하고 싶고, 댓글 답변의 삭제는 진행하고 싶기 때문에, 이벤트 방식으로 풀어봄

하나의 이벤트에 대해 여러 이벤트 리스너가 있을 때, 동작하는 지에 대한 의문이 있었음. 이 부분에 대해서는 리스너의 각 지점에 디버깅 포인트를 찍어 두고 확인을 진행함.

close #102 