### PR TITLE
fix: log4j 이슈 대응

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.cloud:spring-cloud-aws-core:2.2.6.RELEASE'
+    implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
 
     implementation "io.springfox:springfox-boot-starter:3.0.0"
 


### PR DESCRIPTION
log4j 보안 취약점이 저희 프로젝트에도 적용되었기에 log4j 버전을 2.14.1에서 2.17.1로 변경했습니다. 자세한 것은 다음 이슈를 확인해주세요.

Close #165 