### PR TITLE
suggest: CommentController 관련 제안 및 수정사항

### DIFF
--- a/src/main/java/com/gistpetition/api/comment/application/CommentService.java
+++ b/src/main/java/com/gistpetition/api/comment/application/CommentService.java
@@ -34,9 +34,7 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<Comment> getCommentsByPetitionId(Long petitionId) {
-        if (!petitionRepository.existsById(petitionId)) {
-            throw new NoSuchPetitionException();
-        }
+        checkExistenceByPetitionId(petitionId);
         return commentRepository.findByPetitionId(petitionId);
     }
 

--- a/src/main/java/com/gistpetition/api/comment/presentation/CommentController.java
+++ b/src/main/java/com/gistpetition/api/comment/presentation/CommentController.java
@@ -5,6 +5,7 @@ import com.gistpetition.api.comment.application.CommentService;
 import com.gistpetition.api.comment.dto.CommentRequest;
 import com.gistpetition.api.config.annotation.LoginRequired;
 import com.gistpetition.api.config.annotation.LoginUser;
+import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
 import com.gistpetition.api.user.domain.SimpleUser;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,11 +40,17 @@ public class CommentController {
                                                 @PathVariable Long commentId,
                                                 @Validated @RequestBody CommentRequest updateRequest,
                                                 @LoginUser SimpleUser simpleUser) {
-        if (simpleUser.hasManagerAuthority()) {
-            commentService.updateComment(commentId, updateRequest);
-            return ResponseEntity.noContent().build();
-        }
         commentService.updateCommentByOwner(simpleUser.getId(), commentId, updateRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ManagerPermissionRequired
+    @PutMapping("/petitions/{petitionId}/comments/{commentId}/manager")
+    public ResponseEntity<Object> updateCommentByManager(@PathVariable Long petitionId,
+                                                         @PathVariable Long commentId,
+                                                         @Validated @RequestBody CommentRequest updateRequest,
+                                                         @LoginUser SimpleUser simpleUser) {
+        commentService.updateComment(commentId, updateRequest);
         return ResponseEntity.noContent().build();
     }
 
@@ -52,11 +59,16 @@ public class CommentController {
     public ResponseEntity<Object> deleteComment(@PathVariable Long petitionId,
                                                 @PathVariable Long commentId,
                                                 @LoginUser SimpleUser simpleUser) {
-        if (simpleUser.hasManagerAuthority()) {
-            commentService.deleteComment(commentId);
-            return ResponseEntity.noContent().build();
-        }
         commentService.deleteCommentByOwner(simpleUser.getId(), commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ManagerPermissionRequired
+    @DeleteMapping("/petitions/{petitionId}/comments/{commentId}/manager")
+    public ResponseEntity<Object> deleteCommentByManager(@PathVariable Long petitionId,
+                                                         @PathVariable Long commentId,
+                                                         @LoginUser SimpleUser simpleUser) {
+        commentService.deleteComment(commentId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gistpetition/api/user/application/SessionLoginService.java
+++ b/src/main/java/com/gistpetition/api/user/application/SessionLoginService.java
@@ -22,7 +22,7 @@ public class SessionLoginService implements LoginService {
     private final Encoder encoder;
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public void login(SignInRequest request) {
         User user = userRepository.findByUsername(request.getUsername())
                 .orElseThrow(NoSuchUserException::new);

--- a/src/main/java/com/gistpetition/api/user/application/UserService.java
+++ b/src/main/java/com/gistpetition/api/user/application/UserService.java
@@ -35,16 +35,7 @@ public class UserService {
     public Long signUp(SignUpRequest request) {
         String username = request.getUsername();
         String verificationCode = request.getVerificationCode();
-
-        if (userRepository.existsByUsername(username)) {
-            throw new DuplicatedUserException();
-        }
-        if (!EmailDomain.has(EmailParser.parseDomainFrom(username))) {
-            throw new InvalidEmailFormException();
-        }
-
         signUpValidator.checkIsVerified(username, verificationCode);
-
         User user = new User(username, encoder.hashPassword(request.getPassword()), UserRole.USER);
         return userRepository.save(user).getId();
     }


### PR DESCRIPTION
우리 코드를 다시 보면서 같이 논의해보면서 바꾸면 좋지 않을까 하는 부분들을 바꾸어 보았는데,
이런 경우 pr명을 어떤 것으로 해야 할지 몰라서 suggest로 날립니다!

1. CommentController에서 update,delete시 매니저권한이 있는지 검증하는 로직을 지우는 방안을 생각해보았습니다.

일반 사용자라면 update,delete시에 원래대로 .../{commentId}/ url로 요청을 보내도록 하고,
매니저라면 update,delete시에 .../{commentId}/manager가 추가로 붙은 url로 요청을 보내도록 하면 어떨까합니다.

그 외로,

- commentService 에 있는 getCommentsByPetitionId 에서 게시글검증로직을 지우고 checkExistenceByPetitionId를 쓰도록 했습니다.
- login에 있는 @Transactional 에  readonly=True 옵션을 붙였습니다.
  