### PR TITLE
chore: commentService 코드 정리, login의 transaction에 readOnly=true 설정

### DIFF
--- a/src/main/java/com/gistpetition/api/comment/application/CommentService.java
+++ b/src/main/java/com/gistpetition/api/comment/application/CommentService.java
@@ -34,9 +34,7 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<Comment> getCommentsByPetitionId(Long petitionId) {
-        if (!petitionRepository.existsById(petitionId)) {
-            throw new NoSuchPetitionException();
-        }
+        checkExistenceByPetitionId(petitionId);
         return commentRepository.findByPetitionId(petitionId);
     }
 

--- a/src/main/java/com/gistpetition/api/user/application/SessionLoginService.java
+++ b/src/main/java/com/gistpetition/api/user/application/SessionLoginService.java
@@ -22,7 +22,7 @@ public class SessionLoginService implements LoginService {
     private final Encoder encoder;
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public void login(SignInRequest request) {
         User user = userRepository.findByUsername(request.getUsername())
                 .orElseThrow(NoSuchUserException::new);


### PR DESCRIPTION
1. commentService의 getCommentsByPetitionId 메소드에서 기존에 있는 검증메소드를 사용하도록 했고,
2. login 시의 @transactional에 readOnly=true를 걸어주었습니다.