### PR TITLE
refactor: 청원목록을 반환하는 경우 PetitionPreviewResponse를 반환하도록 수정

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -6,6 +6,7 @@ import com.gistpetition.api.exception.user.NoSuchUserException;
 import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.Petition;
 import com.gistpetition.api.petition.domain.PetitionRepository;
+import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.petition.dto.PetitionResponse;
 import com.gistpetition.api.user.domain.User;
@@ -39,23 +40,23 @@ public class PetitionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionResponse> retrievePetition(Pageable pageable) {
-        return PetitionResponse.pageOf(petitionRepository.findAll(pageable));
+    public Page<PetitionPreviewResponse> retrievePetition(Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAll(pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionResponse> retrievePetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionResponse.pageOf(petitionRepository.findByCategory(Category.getById(categoryId), pageable));
+    public Page<PetitionPreviewResponse> retrievePetitionByCategoryId(Long categoryId, Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findByCategory(Category.getById(categoryId), pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionResponse> retrievePetitionByKeyword(String keyword, Pageable pageable) {
-        return PetitionResponse.pageOf(petitionRepository.findByTitleContains(keyword, pageable));
+    public Page<PetitionPreviewResponse> retrievePetitionByKeyword(String keyword, Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findByTitleContains(keyword, pageable));
     }
 
     @Transactional(readOnly = true)
-    public List<Petition> retrievePetitionsByUserId(Long user_id) {
-        return petitionRepository.findByUserId(Sort.by(Sort.Direction.DESC, "id"), user_id);
+    public Page<PetitionPreviewResponse> retrievePetitionsByUserId(Long user_id,Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findByUserId(user_id,pageable));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Repository
 public interface PetitionRepository extends JpaRepository<Petition, Long> {
-    List<Petition> findByUserId(Sort sort, Long userId);
+    Page<Petition> findByUserId(Long userId,Pageable pageable);
 
     Page<Petition> findByCategory(Category category, Pageable pageable);
 

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -4,11 +4,8 @@ import com.gistpetition.api.petition.domain.Petition;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
@@ -20,8 +17,7 @@ public class PetitionPreviewResponse {
     private final LocalDateTime createdAt;
 
     public static Page<PetitionPreviewResponse> pageOf(Page<Petition> page) {
-        List<PetitionPreviewResponse> petitionResponseList = page.getContent().stream().map(PetitionPreviewResponse::of).collect(Collectors.toList());
-        return new PageImpl<>(petitionResponseList, page.getPageable(), page.getTotalElements());
+        return page.map(PetitionPreviewResponse::of);
     }
 
     public static PetitionPreviewResponse of(Petition petition) {

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -1,0 +1,36 @@
+package com.gistpetition.api.petition.dto;
+
+import com.gistpetition.api.petition.domain.Petition;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class PetitionPreviewResponse {
+    private final Long id;
+    private final String title;
+    private final String categoryName;
+    private final Integer agreements;
+    private final LocalDateTime createdAt;
+
+    public static Page<PetitionPreviewResponse> pageOf(Page<Petition> page) {
+        List<PetitionPreviewResponse> petitionResponseList = page.getContent().stream().map(PetitionPreviewResponse::of).collect(Collectors.toList());
+        return new PageImpl<>(petitionResponseList, page.getPageable(), page.getTotalElements());
+    }
+
+    public static PetitionPreviewResponse of(Petition petition) {
+        return new PetitionPreviewResponse(
+                petition.getId(),
+                petition.getTitle(),
+                petition.getCategory().getName(),
+                petition.getAgreements().size(),
+                petition.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
@@ -4,11 +4,8 @@ import com.gistpetition.api.petition.domain.Petition;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
@@ -24,8 +21,7 @@ public class PetitionResponse {
     private final LocalDateTime updatedAt;
 
     public static Page<PetitionResponse> pageOf(Page<Petition> page) {
-        List<PetitionResponse> petitionResponseList = page.getContent().stream().map(PetitionResponse::of).collect(Collectors.toList());
-        return new PageImpl<>(petitionResponseList, page.getPageable(), page.getTotalElements());
+        return page.map(PetitionResponse::of);
     }
 
     public static PetitionResponse of(Petition petition) {

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -5,6 +5,7 @@ import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
 import com.gistpetition.api.petition.application.PetitionService;
 import com.gistpetition.api.petition.domain.Petition;
+import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.petition.dto.PetitionResponse;
 import com.gistpetition.api.user.domain.SimpleUser;
@@ -34,8 +35,8 @@ public class PetitionController {
     }
 
     @GetMapping("/petitions")
-    public ResponseEntity<Page<PetitionResponse>> retrievePetition(@RequestParam(defaultValue = "0") Long categoryId,
-                                                                   @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetition(@RequestParam(defaultValue = "0") Long categoryId,
+                                                                          @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
             return ResponseEntity.ok().body(petitionService.retrievePetition(pageable));
         }
@@ -43,8 +44,8 @@ public class PetitionController {
     }
 
     @GetMapping("/petitions/search")
-    public ResponseEntity<Page<PetitionResponse>> retrievePetitionsByKeyword(@RequestParam(defaultValue = "") String keyword,
-                                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsByKeyword(@RequestParam(defaultValue = "") String keyword,
+                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (keyword.equals("")) {
             return ResponseEntity.ok().body(petitionService.retrievePetition(pageable));
         }
@@ -58,8 +59,8 @@ public class PetitionController {
 
     @LoginRequired
     @GetMapping("/petitions/me")
-    public ResponseEntity<List<Petition>> retrievePetitionsByUserId(@LoginUser SimpleUser simpleUser) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionsByUserId(simpleUser.getId()));
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsByUserId(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @LoginUser SimpleUser simpleUser) {
+        return ResponseEntity.ok().body(petitionService.retrievePetitionsByUserId(simpleUser.getId(),pageable));
     }
 
     @GetMapping("/petitions/count")


### PR DESCRIPTION
클라이언트에서 청원들의 목록을 요청하는 경우에는 각 청원들의 세부정보들까지 보내줄 필요가 없으므로
PetitionResponse에서 (청원의 내용, 작성자, 답변완료여부, 업데이트날짜)를 
제외한 PetitionPreviewResponse를 반환하도록 했습니다.
Close #161 