### PR TITLE
fix: petition의 제목,카테고리도 수정 가능하도록 수정.

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -31,7 +31,7 @@ public class PetitionService {
         return petitionRepository.save(
                 new Petition(petitionRequest.getTitle(),
                         petitionRequest.getDescription(),
-                        Category.getById(petitionRequest.getCategoryId()),
+                        Category.of(petitionRequest.getCategoryId()),
                         userId)
         ).getId();
     }
@@ -43,7 +43,7 @@ public class PetitionService {
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrievePetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findByCategory(Category.getById(categoryId), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findByCategory(Category.of(categoryId), pageable));
     }
 
     @Transactional(readOnly = true)
@@ -70,7 +70,7 @@ public class PetitionService {
     public void updatePetition(Long petitionId, PetitionRequest petitionRequest) {
         Petition petition = findPetitionById(petitionId);
         petition.setTitle(petitionRequest.getTitle());
-        petition.setCategory(Category.getById(petitionRequest.getCategoryId()));
+        petition.setCategory(Category.of(petitionRequest.getCategoryId()));
         petition.setDescription(petitionRequest.getDescription());
     }
 

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -15,11 +15,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -55,8 +52,8 @@ public class PetitionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrievePetitionsByUserId(Long user_id,Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findByUserId(user_id,pageable));
+    public Page<PetitionPreviewResponse> retrievePetitionsByUserId(Long user_id, Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findByUserId(user_id, pageable));
     }
 
     @Transactional(readOnly = true)
@@ -70,9 +67,11 @@ public class PetitionService {
     }
 
     @Transactional
-    public void updatePetitionDescription(Long petitionId, String description) {
+    public void updatePetition(Long petitionId, PetitionRequest petitionRequest) {
         Petition petition = findPetitionById(petitionId);
-        petition.setDescription(description);
+        petition.setTitle(petitionRequest.getTitle());
+        petition.setCategory(Category.getById(petitionRequest.getCategoryId()));
+        petition.setDescription(petitionRequest.getDescription());
     }
 
     @Transactional

--- a/src/main/java/com/gistpetition/api/petition/domain/Category.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Category.java
@@ -34,11 +34,11 @@ public enum Category {
         return name;
     }
 
-    public static Category getById(Long id) {
-        if (id < 0L || values().length < id) {
+    public static Category of(Long categoryId) {
+        if (!lookup.containsKey(categoryId)) {
             throw new NoSuchCategoryException();
         }
-        return lookup.get(id);
+        return lookup.get(categoryId);
     }
 
     private static final Map<Long, Category> lookup = new HashMap<>();

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -68,6 +68,14 @@ public class Petition extends BaseEntity {
         this.answered = b;
     }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
     public void setDescription(String description) {
         this.description = description;
     }

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -4,7 +4,6 @@ import com.gistpetition.api.config.annotation.LoginRequired;
 import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
 import com.gistpetition.api.petition.application.PetitionService;
-import com.gistpetition.api.petition.domain.Petition;
 import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.petition.dto.PetitionResponse;
@@ -19,7 +18,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,7 +58,7 @@ public class PetitionController {
     @LoginRequired
     @GetMapping("/petitions/me")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsByUserId(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @LoginUser SimpleUser simpleUser) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionsByUserId(simpleUser.getId(),pageable));
+        return ResponseEntity.ok().body(petitionService.retrievePetitionsByUserId(simpleUser.getId(), pageable));
     }
 
     @GetMapping("/petitions/count")
@@ -72,7 +70,7 @@ public class PetitionController {
     @PutMapping("/petitions/{petitionId}")
     public ResponseEntity<Void> updatePetition(@PathVariable Long petitionId,
                                                @Validated @RequestBody PetitionRequest changeRequest) {
-        petitionService.updatePetitionDescription(petitionId, changeRequest.getDescription());
+        petitionService.updatePetition(petitionId, changeRequest);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -57,8 +57,8 @@ public class PetitionServiceTest extends ServiceTest {
         Petition petition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
 
         LocalDateTime initialTime = petition.getUpdatedAt();
-
-        petitionService.updatePetitionDescription(petition.getId(), "updated");
+        PetitionRequest petitionUpdateRequest = new PetitionRequest("updateTitle", "updateDescription", 2L);
+        petitionService.updatePetition(petition.getId(), petitionUpdateRequest);
 
         Petition updatedPetition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
         LocalDateTime updatedTime = updatedPetition.getUpdatedAt();
@@ -72,7 +72,9 @@ public class PetitionServiceTest extends ServiceTest {
 
         LocalDateTime initialTime = petition.getUpdatedAt();
 
-        assertThatThrownBy(() -> petitionService.updatePetitionDescription(Long.MAX_VALUE, "updated")).isInstanceOf(NoSuchPetitionException.class);
+        PetitionRequest petitionUpdateRequest = new PetitionRequest("updateTitle", "updateDescription", 2L);
+
+        assertThatThrownBy(() -> petitionService.updatePetition(Long.MAX_VALUE, petitionUpdateRequest)).isInstanceOf(NoSuchPetitionException.class);
 
         Petition updatedPetition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
         LocalDateTime updatedTime = updatedPetition.getUpdatedAt();

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PetitionServiceTest extends ServiceTest {
-    private static final PetitionRequest PETITION_REQUEST_DTO = new PetitionRequest("title", "description", 1L);
+    private static final PetitionRequest DORM_PETITION_REQUEST = new PetitionRequest("title", "description", Category.DORMITORY.getId());
     @Autowired
     private PetitionService petitionService;
     @Autowired
@@ -41,49 +41,51 @@ public class PetitionServiceTest extends ServiceTest {
 
     @Test
     void createPetition() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         Petition petition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
 
-        assertThat(petition.getTitle()).isEqualTo(PETITION_REQUEST_DTO.getTitle());
-        assertThat(petition.getDescription()).isEqualTo(PETITION_REQUEST_DTO.getDescription());
-        assertThat(petition.getCategory().getId()).isEqualTo(PETITION_REQUEST_DTO.getCategoryId());
+        assertThat(petition.getTitle()).isEqualTo(DORM_PETITION_REQUEST.getTitle());
+        assertThat(petition.getDescription()).isEqualTo(DORM_PETITION_REQUEST.getDescription());
+        assertThat(petition.getCategory().getId()).isEqualTo(DORM_PETITION_REQUEST.getCategoryId());
         assertThat(petition.getUserId()).isEqualTo(petitionOwner.getId());
         Assertions.assertThat(petition.getCreatedAt()).isNotNull();
     }
 
     @Test
     void updatePetition() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         Petition petition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
 
         LocalDateTime initialTime = petition.getUpdatedAt();
-        PetitionRequest petitionUpdateRequest = new PetitionRequest("updateTitle", "updateDescription", 2L);
-        petitionService.updatePetition(petition.getId(), petitionUpdateRequest);
+        PetitionRequest updateRequest = new PetitionRequest("updateTitle", "updateDescription", Category.FACILITY.getId());
+        petitionService.updatePetition(petition.getId(), updateRequest);
 
         Petition updatedPetition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
-        LocalDateTime updatedTime = updatedPetition.getUpdatedAt();
-        assertTrue(updatedTime.isAfter(initialTime));
+
+        assertThat(updatedPetition.getTitle()).isEqualTo(updateRequest.getTitle());
+        assertThat(updatedPetition.getDescription()).isEqualTo(updateRequest.getDescription());
+        assertThat(updatedPetition.getCategory()).isEqualTo(Category.getById(updateRequest.getCategoryId()));
+        assertTrue(updatedPetition.getUpdatedAt().isAfter(initialTime));
     }
 
     @Test
     void updatePetitionByNonExistentPetitionId() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         Petition petition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
 
         LocalDateTime initialTime = petition.getUpdatedAt();
 
-        PetitionRequest petitionUpdateRequest = new PetitionRequest("updateTitle", "updateDescription", 2L);
+        PetitionRequest petitionUpdateRequest = new PetitionRequest("updateTitle", "updateDescription", Category.FACILITY.getId());
 
         assertThatThrownBy(() -> petitionService.updatePetition(Long.MAX_VALUE, petitionUpdateRequest)).isInstanceOf(NoSuchPetitionException.class);
 
         Petition updatedPetition = petitionRepository.findById(petitionId).orElseThrow(IllegalArgumentException::new);
-        LocalDateTime updatedTime = updatedPetition.getUpdatedAt();
-        assertTrue(updatedTime.isEqual(initialTime));
+        assertTrue(updatedPetition.getUpdatedAt().isEqual(initialTime));
     }
 
     @Test
     void agree() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
 
         Petition petition = petitionRepository.findPetitionByWithEagerMode(petitionId);
         Assertions.assertThat(petition.getAgreements()).hasSize(0);
@@ -95,7 +97,7 @@ public class PetitionServiceTest extends ServiceTest {
 
     @Test
     void numberOfAgreements() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
 
         User user = userRepository.save(new User("email@email.com", "password", UserRole.USER));
         User user3 = userRepository.save(new User("email3@email.com", "password", UserRole.USER));
@@ -111,7 +113,7 @@ public class PetitionServiceTest extends ServiceTest {
 
     @Test
     void getStateOfAgreement() {
-        Long petitionId = petitionService.createPetition(PETITION_REQUEST_DTO, petitionOwner.getId());
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         assertThat(petitionService.getStateOfAgreement(petitionId, petitionOwner.getId())).isFalse();
 
         petitionService.agree(petitionId, petitionOwner.getId());

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -64,7 +64,7 @@ public class PetitionServiceTest extends ServiceTest {
 
         assertThat(updatedPetition.getTitle()).isEqualTo(updateRequest.getTitle());
         assertThat(updatedPetition.getDescription()).isEqualTo(updateRequest.getDescription());
-        assertThat(updatedPetition.getCategory()).isEqualTo(Category.getById(updateRequest.getCategoryId()));
+        assertThat(updatedPetition.getCategory()).isEqualTo(Category.of(updateRequest.getCategoryId()));
         assertTrue(updatedPetition.getUpdatedAt().isAfter(initialTime));
     }
 

--- a/src/test/java/com/gistpetition/api/petition/domain/CategoryTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/CategoryTest.java
@@ -1,0 +1,23 @@
+package com.gistpetition.api.petition.domain;
+
+import com.gistpetition.api.exception.petition.NoSuchCategoryException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CategoryTest {
+    @Test
+    void findCategoryOfExistingId() {
+        Category[] values = Category.values();
+        for (Category value : values) {
+            assertThat(Category.of(value.getId())).isEqualTo(value);
+        }
+    }
+
+    @Test
+    void findCategoryOfNonExistingId() {
+        Long NonExistingId = Long.MAX_VALUE;
+        assertThatThrownBy(() -> Category.of(NonExistingId)).isInstanceOf(NoSuchCategoryException.class);
+    }
+}

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -1,8 +1,6 @@
-package com.gistpetition.api.petition;
+package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
-import com.gistpetition.api.petition.domain.Category;
-import com.gistpetition.api.petition.domain.Petition;
 import com.gistpetition.api.user.domain.User;
 import com.gistpetition.api.user.domain.UserRole;
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
description뿐만 아니라 title,description도 수정가능하도록 했습니다.

close #189 