### PR TITLE
refactor: Petition Agreement 양방향 설정

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -3,7 +3,6 @@ package com.gistpetition.api.petition.application;
 
 import com.gistpetition.api.exception.petition.NoSuchPetitionException;
 import com.gistpetition.api.exception.user.NoSuchUserException;
-import com.gistpetition.api.petition.dto.PetitionRevisionResponse;
 import com.gistpetition.api.petition.domain.*;
 import com.gistpetition.api.petition.dto.*;
 import com.gistpetition.api.user.domain.User;
@@ -95,7 +94,9 @@ public class PetitionService {
     public void agree(AgreementRequest request, Long petitionId, Long userId) {
         Petition petition = findPetitionById(petitionId);
         User user = findUserById(userId);
-        petition.applyAgreement(user, request.getDescription());
+        Agreement agreement = new Agreement(request.getDescription(), user.getId());
+        agreement.setPetition(petition);
+        agreementRepository.save(agreement);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -16,16 +16,21 @@ public class Agreement extends UnmodifiableEntity {
     private String description;
     private Long userId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "petition_id")
     private Petition petition;
 
     protected Agreement() {
     }
 
-    public Agreement(Long userId, String description, Petition petition) {
+    public Agreement(String description, Long userId) {
+        this(null, description, userId, null);
+    }
+
+    public Agreement(String description, Long userId, Petition petition) {
         this(null, description, userId, petition);
     }
+
 
     private Agreement(Long id, String description, Long userId, Petition petition) {
         this.id = id;
@@ -34,7 +39,13 @@ public class Agreement extends UnmodifiableEntity {
         this.petition = petition;
     }
 
-    public boolean isAgreedBy(Long userId) {
+
+    public boolean writtenBy(Long userId) {
         return this.userId.equals(userId);
+    }
+
+    public void setPetition(Petition petition) {
+        this.petition = petition;
+        petition.addAgreement(this);
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -26,7 +26,6 @@ public class Petition extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Category category;
     private boolean answered;
-    private int accepted;
     private Long userId;
     @NotAudited
     @BatchSize(size = 10)
@@ -37,16 +36,15 @@ public class Petition extends BaseEntity {
     }
 
     public Petition(String title, String description, Category category, Long userId) {
-        this(null, title, description, category, false, 0, userId);
+        this(null, title, description, category, false, userId);
     }
 
-    private Petition(Long id, String title, String description, Category category, boolean answered, int accepted, Long userId) {
+    private Petition(Long id, String title, String description, Category category, boolean answered, Long userId) {
         this.id = id;
         this.title = title;
         this.description = description;
         this.category = category;
         this.answered = answered;
-        this.accepted = accepted;
         this.userId = userId;
     }
 

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -182,8 +182,11 @@ public class PetitionServiceTest extends ServiceTest {
     @Test
     void deletePetition() {
         Petition petition = petitionRepository.save(new Petition("title", "description", Category.DORMITORY, petitionOwner.getId()));
+        petitionService.agree(AGREEMENT_REQUEST, petition.getId(), petitionOwner.getId());
         petitionService.deletePetition(petition.getId());
         assertFalse(petitionRepository.existsById(petition.getId()));
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        assertThat(agreementRepository.findAgreementsByPetitionId(pageRequest,petition.getId())).hasSize(0);
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -24,25 +24,28 @@ class PetitionTest {
     @Test
     void agree() {
         assertThat(petition.getAgreements()).hasSize(0);
-        petition.applyAgreement(user, AGREEMENT_DESCRIPTION);
+        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
+        petition.addAgreement(agreement);
         assertThat(petition.getAgreements()).hasSize(1);
     }
 
     @Test
-    void agreeTwiceFailTest() {
-        petition.applyAgreement(user, AGREEMENT_DESCRIPTION);
+    void agreeFailedWhenSameUserAgreeTwice() {
+        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
+        petition.addAgreement(agreement);
+        Agreement secondaryAgreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
         assertThatThrownBy(
-                () -> petition.applyAgreement(user, AGREEMENT_DESCRIPTION)
+                () -> petition.addAgreement(secondaryAgreement)
         ).isInstanceOf(DuplicatedAgreementException.class);
     }
 
     @Test
     void agreeByMultipleUser() {
-        User user = new User(2L, "email@email.com", "password", UserRole.USER);
-        User user3 = new User(3L, "email@email.com", "password", UserRole.USER);
-        petition.applyAgreement(this.user, AGREEMENT_DESCRIPTION);
-        petition.applyAgreement(user, AGREEMENT_DESCRIPTION);
-        petition.applyAgreement(user3, AGREEMENT_DESCRIPTION);
+        User user1 = new User(2L, "email@email.com", "password", UserRole.USER);
+        User user2 = new User(3L, "email@email.com", "password", UserRole.USER);
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user.getId()));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user1.getId()));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user2.getId()));
         assertThat(petition.getAgreements()).hasSize(3);
     }
 }


### PR DESCRIPTION
Petition과 Agreement 간의 관계를 양방향으로 변경했습니다. 그렇기에 영속성 전이가 이어지지 않고 agreementRepository에 직접 저장이 되는 방식입니다. 이외에도 agreementCount field를 제거했습니다.

Close #185 
