### PR TITLE
feat: 동시에 여러 동의 요청시 하나의 동의만을 허용하는 기능 구현

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -7,6 +7,7 @@ import javax.persistence.*;
 
 @Getter
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "petition_id"}))
 public class Agreement extends UnmodifiableEntity {
 
     @Id
@@ -14,6 +15,7 @@ public class Agreement extends UnmodifiableEntity {
     private Long id;
     @Lob
     private String description;
+    @Column(name = "user_id")
     private Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -1,7 +1,6 @@
 package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.common.persistence.BaseEntity;
-import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.user.domain.User;
 import lombok.Getter;
 import org.hibernate.annotations.BatchSize;
@@ -49,11 +48,6 @@ public class Petition extends BaseEntity {
     }
 
     public void addAgreement(Agreement newAgreement) {
-        for (Agreement agreement : agreements) {
-            if (agreement.writtenBy(newAgreement.getUserId())) {
-                throw new DuplicatedAgreementException();
-            }
-        }
         this.agreements.add(newAgreement);
     }
 

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -4,10 +4,12 @@ import com.gistpetition.api.config.annotation.AdminPermissionRequired;
 import com.gistpetition.api.config.annotation.LoginRequired;
 import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
+import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.petition.application.PetitionService;
 import com.gistpetition.api.petition.dto.*;
 import com.gistpetition.api.user.domain.SimpleUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -93,7 +95,11 @@ public class PetitionController {
     public ResponseEntity<Void> agreePetition(@RequestBody AgreementRequest agreementRequest,
                                               @PathVariable Long petitionId,
                                               @LoginUser SimpleUser simpleUser) {
-        petitionService.agree(agreementRequest, petitionId, simpleUser.getId());
+        try {
+            petitionService.agree(agreementRequest, petitionId, simpleUser.getId());
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicatedAgreementException();
+        }
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -1,7 +1,6 @@
 package com.gistpetition.api.petition;
 
 import com.gistpetition.api.ServiceTest;
-import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.exception.petition.NoSuchPetitionException;
 import com.gistpetition.api.petition.application.PetitionService;
 import com.gistpetition.api.petition.domain.*;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -144,14 +144,13 @@ public class PetitionServiceTest extends ServiceTest {
             service.execute(() -> {
                 try {
                     petitionService.agree(agreementRequest, petitionId, petitionOwner.getId());
-                } catch (DuplicatedAgreementException e) {
+                } catch (DataIntegrityViolationException e) {
                     System.out.println("---동의 중복---" + agreementRequest.getDescription());
                 }
                 latch.countDown();
             });
         }
         latch.await();
-        petitionService.retrieveAgreements(petitionId, PageRequest.of(0, 10));
         assertThat(petitionService.retrieveNumberOfAgreements(petitionId)).isEqualTo(1);
     }
 

--- a/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionServiceTest.java
@@ -133,6 +133,17 @@ public class PetitionServiceTest extends ServiceTest {
     }
 
     @Test
+    void agreeTwiceByOneUser() {
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
+
+        petitionService.agree(AGREEMENT_REQUEST, petitionId, petitionOwner.getId());
+
+        assertThatThrownBy(
+                () -> petitionService.agree(AGREEMENT_REQUEST, petitionId, petitionOwner.getId())
+        ).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
     public void applyAgreementWithConcurrency() throws InterruptedException {
         Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         int numberOfThreads = 10;
@@ -271,7 +282,6 @@ public class PetitionServiceTest extends ServiceTest {
         Page<PetitionRevisionResponse> revisionResponses = petitionService.retrieveRevisionsOfPetition(petitionId, pageRequest);
         assertThat(revisionResponses.getContent()).hasSize(2);
         assertThat(revisionResponses.getContent()).allMatch(content -> content.getWorkedBy().equals(petitionOwner.getId()));
-        assertThat(revisionResponses.getContent()).allMatch(content -> content.getWorkedBy() == petitionOwner.getId());
         List<PetitionRevisionResponse> content = revisionResponses.getContent();
         List<RevisionMetadata.RevisionType> revisionTypes = content.stream().map(PetitionRevisionResponse::getRevisionType).collect(Collectors.toList());
         assertThat(revisionTypes).containsExactly(RevisionMetadata.RevisionType.INSERT, RevisionMetadata.RevisionType.UPDATE);

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -1,13 +1,11 @@
 package com.gistpetition.api.petition.domain;
 
-import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.user.domain.User;
 import com.gistpetition.api.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PetitionTest {
     private static final String AGREEMENT_DESCRIPTION = "동의합니다.";
@@ -27,16 +25,6 @@ class PetitionTest {
         Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
         petition.addAgreement(agreement);
         assertThat(petition.getAgreements()).hasSize(1);
-    }
-
-    @Test
-    void agreeFailedWhenSameUserAgreeTwice() {
-        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
-        petition.addAgreement(agreement);
-        Agreement secondaryAgreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
-        assertThatThrownBy(
-                () -> petition.addAgreement(secondaryAgreement)
-        ).isInstanceOf(DuplicatedAgreementException.class);
     }
 
     @Test


### PR DESCRIPTION
기존에는 db의 데이터를 모두 불러와서 메모리에 올려두고 이를 검증을 진행했기 때문에, 동시성 문제에 대해서 취약하다. 이를 agreement에 (petition_id, user_id)에 unique constraints를 걸어 둠으로써 db에 저장시 하나만 적용되도록 강제할 수 있다. 이 방법을 answer의 경우에도 적용할 수 있을 것으로 보인다.

한 가지 고민되는 부분은, 기존의 DuplicatedAgreementException과 같은 ApplicationException을 만들어 줄 방법에 대해 고민되는 부분이다. 트랜잭션이 커밋되는 시점에 에러가 발생하는 것이기 때문에 Controller코드 단에서 이를 업그레이드 시켜줘야 하는데 이 방법이 좋은 구현인지에 대한 것은 의문점이 남는 부분이다.

close #207 