### PR TITLE
feature: Temp Url 기능 구현 진행

### DIFF
--- a/src/main/java/com/gistpetition/api/exception/petition/DuplicatedTempUrlException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/DuplicatedTempUrlException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicatedTempUrlException extends PetitionException {
+    private static final String MESSAGE = "이미 청원에 링크가 존재합니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public DuplicatedTempUrlException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/exception/petition/NoSuchTempUrlException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/NoSuchTempUrlException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchTempUrlException extends PetitionException {
+    private static final String MESSAGE = "해당 URL의 청원은 존재하지 않습니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    public NoSuchTempUrlException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -60,6 +60,11 @@ public class PetitionService {
     }
 
     @Transactional(readOnly = true)
+    public TempPetitionResponse retrieveTempPetitionById(Long petitionId, String tempUrl) {
+        return TempPetitionResponse.of(findPetitionById(petitionId), tempUrl);
+    }
+
+    @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveAnsweredPetition(Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findByAnsweredTrue(pageable));
     }

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -7,7 +7,7 @@ import com.gistpetition.api.petition.domain.*;
 import com.gistpetition.api.petition.dto.*;
 import com.gistpetition.api.user.domain.User;
 import com.gistpetition.api.user.domain.UserRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class PetitionService {
 
     private final PetitionRepository petitionRepository;
@@ -25,12 +25,13 @@ public class PetitionService {
 
     @Transactional
     public Long createPetition(PetitionRequest petitionRequest, Long userId) {
-        return petitionRepository.save(
+        Petition created = petitionRepository.save(
                 new Petition(petitionRequest.getTitle(),
                         petitionRequest.getDescription(),
                         Category.of(petitionRequest.getCategoryId()),
                         userId)
-        ).getId();
+        );
+        return created.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/application/TempPetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/TempPetitionService.java
@@ -1,0 +1,38 @@
+package com.gistpetition.api.petition.application;
+
+import com.gistpetition.api.exception.petition.DuplicatedTempUrlException;
+import com.gistpetition.api.exception.petition.NoSuchTempUrlException;
+import com.gistpetition.api.petition.domain.TempPetitionUrl;
+import com.gistpetition.api.petition.domain.TempPetitionUrlRepository;
+import com.gistpetition.api.utils.urlGenerator.UrlGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TempPetitionService {
+    public static final int TEMP_URL_LENGTH = 6;
+
+    private final TempPetitionUrlRepository tempPetitionUrlRepository;
+    private final UrlGenerator urlGenerator;
+
+    @Transactional
+    public String createTempUrl(Long petitionId) {
+        if (tempPetitionUrlRepository.existsByPetitionId(petitionId)) {
+            throw new DuplicatedTempUrlException();
+        }
+        String generatedUrl = urlGenerator.generate(TEMP_URL_LENGTH);
+        while (tempPetitionUrlRepository.existsByTempUrlEquals(generatedUrl)) {
+            generatedUrl = urlGenerator.generate(TEMP_URL_LENGTH);
+        }
+        TempPetitionUrl tempPetitionUrl = tempPetitionUrlRepository.save(new TempPetitionUrl(petitionId, generatedUrl));
+        return tempPetitionUrl.getTempUrl();
+    }
+
+    public Long findPetitionIdByTempUrl(String tempUrl) {
+        TempPetitionUrl tempPetitionUrl = tempPetitionUrlRepository.findByTempUrl(tempUrl)
+                .orElseThrow(NoSuchTempUrlException::new);
+        return tempPetitionUrl.getPetitionId();
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/application/TempPetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/TempPetitionService.java
@@ -23,9 +23,6 @@ public class TempPetitionService {
             throw new DuplicatedTempUrlException();
         }
         String generatedUrl = urlGenerator.generate(TEMP_URL_LENGTH);
-        while (tempPetitionUrlRepository.existsByTempUrlEquals(generatedUrl)) {
-            generatedUrl = urlGenerator.generate(TEMP_URL_LENGTH);
-        }
         TempPetitionUrl tempPetitionUrl = tempPetitionUrlRepository.save(new TempPetitionUrl(petitionId, generatedUrl));
         return tempPetitionUrl.getTempUrl();
     }

--- a/src/main/java/com/gistpetition/api/petition/domain/TempPetitionUrl.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/TempPetitionUrl.java
@@ -1,0 +1,29 @@
+package com.gistpetition.api.petition.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class TempPetitionUrl {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "petition_id", unique = true)
+    private Long petitionId;
+    @Column(name = "temp_url", unique = true)
+    private String tempUrl;
+
+    public TempPetitionUrl(Long petitionId, String tempUrl) {
+        this(null, petitionId, tempUrl);
+    }
+
+    private TempPetitionUrl(Long id, Long petitionId, String tempUrl) {
+        this.id = id;
+        this.petitionId = petitionId;
+        this.tempUrl = tempUrl;
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/domain/TempPetitionUrlRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/TempPetitionUrlRepository.java
@@ -1,0 +1,13 @@
+package com.gistpetition.api.petition.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TempPetitionUrlRepository extends JpaRepository<TempPetitionUrl, Long> {
+    Boolean existsByTempUrlEquals(String tempUrl);
+
+    Boolean existsByPetitionId(Long petitionId);
+
+    Optional<TempPetitionUrl> findByTempUrl(String tempUrl);
+}

--- a/src/main/java/com/gistpetition/api/petition/dto/TempPetitionResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/TempPetitionResponse.java
@@ -1,0 +1,35 @@
+package com.gistpetition.api.petition.dto;
+
+import com.gistpetition.api.petition.domain.Petition;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class TempPetitionResponse {
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final String categoryName;
+    private final Boolean answered;
+    private final Long userId;
+    private final Integer agreements;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final String tempUrl;
+
+    public static TempPetitionResponse of(Petition petition, String tempUrl) {
+        return new TempPetitionResponse(
+                petition.getId(),
+                petition.getTitle(),
+                petition.getDescription(),
+                petition.getCategory().getName(),
+                petition.isAnswered(),
+                petition.getUserId(),
+                petition.getAgreements().size(),
+                petition.getCreatedAt(),
+                petition.getUpdatedAt(),
+                tempUrl
+        );
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -6,6 +6,7 @@ import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
 import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.petition.application.PetitionService;
+import com.gistpetition.api.petition.application.TempPetitionService;
 import com.gistpetition.api.petition.dto.*;
 import com.gistpetition.api.user.domain.SimpleUser;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +26,15 @@ import java.net.URI;
 @RequestMapping("/v1")
 public class PetitionController {
     private final PetitionService petitionService;
+    private final TempPetitionService tempPetitionService;
 
     @LoginRequired
     @PostMapping("/petitions")
     public ResponseEntity<Void> createPetition(@Validated @RequestBody PetitionRequest petitionRequest,
                                                @LoginUser SimpleUser simpleUser) {
-        return ResponseEntity.created(URI.create("/petitions/" + petitionService.createPetition(petitionRequest, simpleUser.getId()))).build();
+        Long createdPetitionId = petitionService.createPetition(petitionRequest, simpleUser.getId());
+        String tempUrl = tempPetitionService.createTempUrl(createdPetitionId);
+        return ResponseEntity.created(URI.create("/petitions/temp/" + tempUrl)).build();
     }
 
     @GetMapping("/petitions")
@@ -119,5 +123,11 @@ public class PetitionController {
     public ResponseEntity<Boolean> retrieveStateOfAgreement(@PathVariable Long petitionId,
                                                             @LoginUser SimpleUser simpleUser) {
         return ResponseEntity.ok().body(petitionService.retrieveStateOfAgreement(petitionId, simpleUser.getId()));
+    }
+
+    @GetMapping("/petitions/temp/{tempUrl}")
+    public ResponseEntity<PetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
+        Long petitionId = tempPetitionService.findPetitionIdByTempUrl(tempUrl);
+        return ResponseEntity.ok().body(petitionService.retrievePetitionById(petitionId));
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -126,8 +126,8 @@ public class PetitionController {
     }
 
     @GetMapping("/petitions/temp/{tempUrl}")
-    public ResponseEntity<PetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
+    public ResponseEntity<TempPetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
         Long petitionId = tempPetitionService.findPetitionIdByTempUrl(tempUrl);
-        return ResponseEntity.ok().body(petitionService.retrievePetitionById(petitionId));
+        return ResponseEntity.ok().body(petitionService.retrieveTempPetitionById(petitionId, tempUrl));
     }
 }

--- a/src/main/java/com/gistpetition/api/utils/urlGenerator/FixedUrlGenerator.java
+++ b/src/main/java/com/gistpetition/api/utils/urlGenerator/FixedUrlGenerator.java
@@ -1,0 +1,15 @@
+package com.gistpetition.api.utils.urlGenerator;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile("!dev && !prod")
+@Component
+public class FixedUrlGenerator implements UrlGenerator {
+    public static final String FIXED_URL = "AAAAAA";
+
+    @Override
+    public String generate(int urlLength) {
+        return FIXED_URL;
+    }
+}

--- a/src/main/java/com/gistpetition/api/utils/urlGenerator/FixedUrlGenerator.java
+++ b/src/main/java/com/gistpetition/api/utils/urlGenerator/FixedUrlGenerator.java
@@ -1,15 +1,10 @@
 package com.gistpetition.api.utils.urlGenerator;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
-@Profile("!dev && !prod")
-@Component
 public class FixedUrlGenerator implements UrlGenerator {
-    public static final String FIXED_URL = "AAAAAA";
+    public static final String URL_CHAR = "A";
 
     @Override
     public String generate(int urlLength) {
-        return FIXED_URL;
+        return URL_CHAR.repeat(urlLength);
     }
 }

--- a/src/main/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGenerator.java
+++ b/src/main/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGenerator.java
@@ -1,0 +1,22 @@
+package com.gistpetition.api.utils.urlGenerator;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Profile("dev || prod")
+@Component
+public class RandomUrlGenerator implements UrlGenerator {
+    private static final char[] keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private final Random random = new Random();
+
+    @Override
+    public String generate(int urlLength) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < urlLength; i++) {
+            sb.append(keys[random.nextInt(keys.length)]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGenerator.java
+++ b/src/main/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGenerator.java
@@ -1,11 +1,9 @@
 package com.gistpetition.api.utils.urlGenerator;
 
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.Random;
 
-@Profile("dev || prod")
 @Component
 public class RandomUrlGenerator implements UrlGenerator {
     private static final char[] keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();

--- a/src/main/java/com/gistpetition/api/utils/urlGenerator/UrlGenerator.java
+++ b/src/main/java/com/gistpetition/api/utils/urlGenerator/UrlGenerator.java
@@ -1,0 +1,5 @@
+package com.gistpetition.api.utils.urlGenerator;
+
+public interface UrlGenerator {
+    String generate(int urlLength);
+}

--- a/src/test/java/com/gistpetition/api/petition/application/TempPetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/TempPetitionServiceTest.java
@@ -1,5 +1,6 @@
 package com.gistpetition.api.petition.application;
 
+import com.gistpetition.api.ServiceTest;
 import com.gistpetition.api.exception.petition.DuplicatedTempUrlException;
 import com.gistpetition.api.exception.petition.NoSuchTempUrlException;
 import com.gistpetition.api.petition.domain.TempPetitionUrl;
@@ -14,8 +15,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-class TempPetitionServiceTest {
+class TempPetitionServiceTest extends ServiceTest {
     @Autowired
     private TempPetitionService tempPetitionService;
     @Autowired

--- a/src/test/java/com/gistpetition/api/petition/application/TempPetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/TempPetitionServiceTest.java
@@ -1,0 +1,56 @@
+package com.gistpetition.api.petition.application;
+
+import com.gistpetition.api.exception.petition.DuplicatedTempUrlException;
+import com.gistpetition.api.exception.petition.NoSuchTempUrlException;
+import com.gistpetition.api.petition.domain.TempPetitionUrl;
+import com.gistpetition.api.petition.domain.TempPetitionUrlRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class TempPetitionServiceTest {
+    @Autowired
+    private TempPetitionService tempPetitionService;
+    @Autowired
+    private TempPetitionUrlRepository tempPetitionUrlRepository;
+
+    @Test
+    void createTempPetition() {
+        Long petitionId = 1L;
+        String tempUrl = tempPetitionService.createTempUrl(petitionId);
+
+        Optional<TempPetitionUrl> tempPetitionUrl = tempPetitionUrlRepository.findByTempUrl(tempUrl);
+        assertThat(tempPetitionUrl).isPresent();
+    }
+
+    @Test
+    void createTempPetitionAlreadyExists() {
+        Long petitionId = 1L;
+        tempPetitionService.createTempUrl(petitionId);
+        assertThatThrownBy(
+                () -> tempPetitionService.createTempUrl(petitionId)
+        ).isInstanceOf(DuplicatedTempUrlException.class);
+    }
+
+
+    @Test
+    void createTempPetitionWithSameTempUrl() {
+        String notExistingTempUrl = "NOT_TEMP";
+
+        assertThatThrownBy(
+                () -> tempPetitionService.findPetitionIdByTempUrl(notExistingTempUrl)
+        ).isInstanceOf(NoSuchTempUrlException.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tempPetitionUrlRepository.deleteAllInBatch();
+    }
+}

--- a/src/test/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGeneratorTest.java
+++ b/src/test/java/com/gistpetition/api/utils/urlGenerator/RandomUrlGeneratorTest.java
@@ -1,0 +1,22 @@
+package com.gistpetition.api.utils.urlGenerator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.gistpetition.api.petition.application.TempPetitionService.TEMP_URL_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RandomUrlGeneratorTest {
+
+    private RandomUrlGenerator tempUrlGenerator;
+
+    @BeforeEach
+    void setUp() {
+        tempUrlGenerator = new RandomUrlGenerator();
+    }
+
+    @Test
+    void generate() {
+        assertThat(tempUrlGenerator.generate(TEMP_URL_LENGTH)).hasSize(TEMP_URL_LENGTH);
+    }
+}


### PR DESCRIPTION
#178 사전 동의 기능의 일부인 temp url을 잘라서 구현진행했습니다.

`/petitions/me` 부분에서 어떤 응답을 전달할지에 대해서 고민해봐야 합니다.