### PR TITLE
feat: 청원 동의 수로 조회 기능 구현

### DIFF
--- a/src/main/java/com/gistpetition/api/DataLoader.java
+++ b/src/main/java/com/gistpetition/api/DataLoader.java
@@ -72,36 +72,40 @@ public class DataLoader implements CommandLineRunner {
         petitionRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
 
-        userRepository.save(new User("admin@gist.ac.kr", PASSWORD, UserRole.ADMIN));
-        userRepository.save(new User("manager@gist.ac.kr", PASSWORD, UserRole.MANAGER));
-        User user = userRepository.save(new User("user@gist.ac.kr", PASSWORD, UserRole.USER));
+        User admin = userRepository.save(new User("admin@gist.ac.kr", PASSWORD, UserRole.ADMIN));
+        User manager = userRepository.save(new User("manager@gist.ac.kr", PASSWORD, UserRole.MANAGER));
+        User normal = userRepository.save(new User("user@gist.ac.kr", PASSWORD, UserRole.USER));
 
         ArrayList<User> alphabetUsers = new ArrayList<>();
         for (char alphabet = 'a'; alphabet <= 'z'; alphabet++) {
             alphabetUsers.add(userRepository.save(new User(alphabet + "@gist.ac.kr", PASSWORD, UserRole.USER)));
         }
 
-        Petition petition1 = savePetition("국민 청원에 글을 써버렸다.", user);
-        Petition petition2 = savePetition("방송 촬영을 위해 안전과 생존을 위협당하는 동물의 대책 마련이 필요합니다", user);
-        Petition petition3 = savePetition("길고양이를 학대하는 갤러리를 폐쇄하고 엄중한 수사를 해주십시오.", user);
-        Petition petition4 = savePetition("코로나19로 부터 우리 아이들을 지켜주세요.", user);
-        Petition petition5 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition6 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition7 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition8 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition9 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition10 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition11 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        Petition petition12 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", user);
-        List<Petition> answeredPetitions = Arrays.asList(petition1, petition2, petition3, petition4, petition5, petition6, petition7, petition8, petition9, petition10, petition11, petition12);
+        Petition petition1 = savePetition("국민 청원에 글을 써버렸다.", normal);
+        Petition petition2 = savePetition("방송 촬영을 위해 안전과 생존을 위협당하는 동물의 대책 마련이 필요합니다", manager);
+        Petition petition3 = savePetition("길고양이를 학대하는 갤러리를 폐쇄하고 엄중한 수사를 해주십시오.", admin);
+        Petition petition4 = savePetition("코로나19로 부터 우리 아이들을 지켜주세요.", normal);
+        Petition petition5 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition6 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition7 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition8 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition9 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition10 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition11 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        Petition petition12 = savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        savePetition("2차방역지원금 지금 자영업분들 농락하시나요?", normal);
+        List<Petition> petitions = Arrays.asList(petition1, petition2, petition3, petition4, petition5, petition6, petition7, petition8, petition9, petition10, petition11, petition12);
 
-        for (Petition petition : answeredPetitions) {
-            for (User alphabetUser : alphabetUsers) {
-                petitionService.agree(AGREEMENT_REQUEST, petition.getId(), alphabetUser.getId());
+        List<Integer> numOfAgree = List.of(26, 13, 16, 21, 6, 9, 8, 5, 5, 21, 17, 16);
+        for (int i = 0; i < petitions.size(); i++) {
+            Petition petition = petitions.get(i);
+            for (int j = 0; j < numOfAgree.get(i); j++) {
+                User user = alphabetUsers.get(j);
+                petitionService.agree(AGREEMENT_REQUEST, petition.getId(), user.getId());
             }
+            petitionService.releasePetition(petition.getId());
             answerService.createAnswer(petition.getId(), new AnswerRequest(ANSWER_CONTENT));
         }
     }

--- a/src/main/java/com/gistpetition/api/DataLoader.java
+++ b/src/main/java/com/gistpetition/api/DataLoader.java
@@ -14,7 +14,6 @@ import com.gistpetition.api.user.domain.UserRepository;
 import com.gistpetition.api.user.domain.UserRole;
 import com.gistpetition.api.utils.password.BcryptEncoder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +25,7 @@ import java.util.List;
 @Profile("dev")
 @RequiredArgsConstructor
 @Component
-public class DataLoader implements CommandLineRunner {
+public class DataLoader {
     public static final String PASSWORD = new BcryptEncoder().hashPassword("test1234!");
     private static final String CONTENT = "해당 드라마는 방영 전 이미 시놉시스 공개로 한차례 민주화운동을 폄훼하는 내용으로 큰 논란이 된 바 있으며 20만명 이상의 국민들이 해당 드라마의 방영 중지 청원에 동의하였습니다. 당시 제작진은 전혀 그럴 의도가 없으며 “남녀 주인공이 민주화 운동에 참여하거나 이끄는 설정은 대본 어디에도 존재하지 않는다.” 라고 주장했습니다. 그러나 1화가 방영된 현재 드라마에서 여주인공은 간첩인 남주인공을 운동권으로 오인해 구해주었습니다.\n" +
             "\n" +
@@ -59,11 +58,6 @@ public class DataLoader implements CommandLineRunner {
     private final PetitionService petitionService;
     private final AnswerService answerService;
     private final AgreementRepository agreementRepository;
-
-    @Override
-    public void run(String... args) {
-        userRepository.save(new User("admin@gist.ac.kr", PASSWORD, UserRole.ADMIN));
-    }
 
     @Transactional
     public void loadData() {

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -136,6 +136,11 @@ public class PetitionService {
         petition.release();
     }
 
+    @Transactional(readOnly = true)
+    public Page<PetitionPreviewResponse> retrievePetitionsOrderByAgreeCount(Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByOrderByAgreeCountDesc(pageable));
+    }
+
     private User findUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(NoSuchUserException::new);
     }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -31,6 +31,8 @@ public class Petition extends BaseEntity {
     private Boolean released = false;
     private Long userId;
     @NotAudited
+    private Long agreeCount = 0L;
+    @NotAudited
     @BatchSize(size = 10)
     @OneToMany(mappedBy = "petition", orphanRemoval = true)
     private final List<Agreement> agreements = new ArrayList<>();
@@ -52,6 +54,7 @@ public class Petition extends BaseEntity {
 
     public void addAgreement(Agreement newAgreement) {
         this.agreements.add(newAgreement);
+        this.agreeCount += 1;
     }
 
     public boolean isAgreedBy(User user) {

--- a/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
@@ -20,6 +20,8 @@ public interface PetitionRepository extends RevisionRepository<Petition, Long, L
 
     Page<Petition> findByAnsweredTrue(Pageable pageable);
 
+    Page<Petition> findAllByOrderByAgreeCountDesc(Pageable pageable);
+
     @Query("SELECT p FROM Petition AS p LEFT JOIN FETCH p.agreements WHERE p.id=:petitionId")
     Petition findPetitionByWithEagerMode(@Param("petitionId") Long petitionId);
 }

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -130,6 +130,11 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveTempPetitionById(petitionId, tempUrl));
     }
 
+    @GetMapping("/petitions/best")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveTempPetition(Pageable pageable) {
+        return ResponseEntity.ok().body(petitionService.retrievePetitionsOrderByAgreeCount(pageable));
+    }
+
     @ManagerPermissionRequired
     @PostMapping("/petitions/{petitionId}/release")
     public ResponseEntity<Void> releasePetition(@PathVariable Long petitionId) {

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -33,6 +33,7 @@ class PetitionTest {
         Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
         petition.addAgreement(agreement);
         assertThat(petition.getAgreements()).hasSize(1);
+        assertThat(petition.getAgreeCount()).isEqualTo(1);
     }
 
     @Test
@@ -43,6 +44,7 @@ class PetitionTest {
         petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user1.getId()));
         petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user2.getId()));
         assertThat(petition.getAgreements()).hasSize(3);
+        assertThat(petition.getAgreeCount()).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
프론트엔드 측에서 빠르게 요구해서, 진행해봤습니다.

우선 agreeCount를 두고 진행했습니다. 이를 우선적으로 사용해보고 이후에 삭제하는 방법을 고민해봐도 좋을 것 같습니다.