### PR TITLE
feat: released petition 인수테스트 작성

### DIFF
--- a/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
@@ -60,6 +60,13 @@ public class LoginAndThenAct {
                 get("/v1/petitions/temp/" + tempUrl);
     }
 
+    public Response retrieveReleasedPetition(Long petitionId) {
+        return given().
+                cookie("JSESSIONID", tUser.getJSessionId()).
+                when().
+                get("/v1/petitions/" + petitionId);
+    }
+
     public Response agreePetition(AgreementRequest agreementRequest, Long petitionId) {
         return given().
                 contentType(ContentType.JSON).

--- a/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
@@ -1,6 +1,7 @@
 package com.gistpetition.api.acceptance.common;
 
 import com.gistpetition.api.answer.dto.AnswerRequest;
+import com.gistpetition.api.petition.dto.AgreementRequest;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.user.domain.UserRole;
 import com.gistpetition.api.user.dto.request.UpdateUserRoleRequest;
@@ -58,6 +59,28 @@ public class LoginAndThenAct {
                 when().
                 get("/v1/petitions/temp/" + tempUrl);
     }
+
+    public Response agreePetition(AgreementRequest agreementRequest, Long petitionId) {
+        return given().
+                contentType(ContentType.JSON).
+                cookie("JSESSIONID", tUser.getJSessionId()).
+                body(agreementRequest).
+                when().
+                post("/v1/petitions/" + petitionId + "/agreements").
+                then().
+                statusCode(HttpStatus.OK.value()).extract().response();
+    }
+
+    public Response releasePetition(Long petitionId) {
+        return given().
+                contentType(ContentType.JSON).
+                cookie("JSESSIONID", tUser.getJSessionId()).
+                when().
+                post("/v1/petitions/" + petitionId + "/release").
+                then().
+                statusCode(HttpStatus.NO_CONTENT.value()).extract().response();
+    }
+
 
     public LoginAndThenAct updateUserRoleAndThen(TUser target, UserRole userRole) {
         UpdateUserRoleRequest updateUserRoleRequest = new UpdateUserRoleRequest(userRole.name());

--- a/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/LoginAndThenAct.java
@@ -67,7 +67,7 @@ public class LoginAndThenAct {
                 get("/v1/petitions/" + petitionId);
     }
 
-    public Response agreePetition(AgreementRequest agreementRequest, Long petitionId) {
+    public Response agreePetitionWith(AgreementRequest agreementRequest, Long petitionId) {
         return given().
                 contentType(ContentType.JSON).
                 cookie("JSESSIONID", tUser.getJSessionId()).

--- a/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
@@ -19,6 +19,11 @@ public enum TUser {
     EUNGI("handsomeGuy@gm.gist.ac.kr", "It's me!"),
     WANNTE("wannte@gm.gist.ac.kr", "wannte"),
     KOSE("kose@gist.ac.kr", "kose"),
+    AGREE_USER1("agree1@gist.ac.kr", "agree1"),
+    AGREE_USER2("agree2@gist.ac.kr", "agree2"),
+    AGREE_USER3("agree3@gist.ac.kr", "agree3"),
+    AGREE_USER4("agree4@gist.ac.kr", "agree4"),
+    AGREE_USER5("agree5@gist.ac.kr", "agree5"),
     ;
 
     private final String username;
@@ -85,7 +90,7 @@ public enum TUser {
                 statusCode(HttpStatus.CREATED.value()).
                 header(HttpHeaders.LOCATION, containsString("/users/")).
                 extract().header(HttpHeaders.LOCATION).split("/");
-        id = Long.valueOf(location[location.length - 1]);
+        id = Long.parseLong(location[location.length - 1]);
     }
 
 
@@ -134,6 +139,10 @@ public enum TUser {
 
     public String getJSessionId() {
         return this.jSessionId;
+    }
+
+    public static TUser[] willAgreeUserArray() {
+        return new TUser[]{AGREE_USER1, AGREE_USER2, AGREE_USER3, AGREE_USER4, AGREE_USER5};
     }
 
 }

--- a/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.containsString;
 
 public enum TUser {
     T_ADMIN("testAdmin@gist.ac.kr", "admin"),
+    T_MANAGER("testManager@gist.ac.kr", "manager"),
     GUNE("gune@gm.gist.ac.kr", "gune"),
     EUNGI("handsomeGuy@gm.gist.ac.kr", "It's me!"),
     WANNTE("wannte@gm.gist.ac.kr", "wannte"),

--- a/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
@@ -140,9 +140,4 @@ public enum TUser {
     public String getJSessionId() {
         return this.jSessionId;
     }
-
-    public static TUser[] willAgreeUserArray() {
-        return new TUser[]{AGREE_USER1, AGREE_USER2, AGREE_USER3, AGREE_USER4, AGREE_USER5};
-    }
-
 }

--- a/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/TUser.java
@@ -91,7 +91,7 @@ public enum TUser {
                 statusCode(HttpStatus.CREATED.value()).
                 header(HttpHeaders.LOCATION, containsString("/users/")).
                 extract().header(HttpHeaders.LOCATION).split("/");
-        id = Long.parseLong(location[location.length - 1]);
+        id = Long.valueOf(location[location.length - 1]);
     }
 
 

--- a/src/test/java/com/gistpetition/api/acceptance/common/TestDataLoader.java
+++ b/src/test/java/com/gistpetition/api/acceptance/common/TestDataLoader.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import static com.gistpetition.api.acceptance.common.TUser.T_ADMIN;
+import static com.gistpetition.api.acceptance.common.TUser.T_MANAGER;
 
 @Profile("acceptance")
 @Component
@@ -24,5 +25,6 @@ public class TestDataLoader implements CommandLineRunner {
     @Override
     public void run(String... args) {
         userRepository.save(new User(T_ADMIN.getUsername(), encoder.hashPassword(T_ADMIN.getPassword()), UserRole.ADMIN));
+        userRepository.save(new User(T_MANAGER.getUsername(), encoder.hashPassword(T_MANAGER.getPassword()), UserRole.MANAGER));
     }
 }

--- a/src/test/java/com/gistpetition/api/acceptance/petition/CreatePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/CreatePetitionAcceptanceTest.java
@@ -5,7 +5,6 @@ import com.gistpetition.api.acceptance.common.TUser;
 import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.PetitionRepository;
 import com.gistpetition.api.petition.dto.PetitionRequest;
-import com.gistpetition.api.user.domain.UserRepository;
 import com.gistpetition.api.user.domain.UserRole;
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;

--- a/src/test/java/com/gistpetition/api/acceptance/petition/CreatePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/CreatePetitionAcceptanceTest.java
@@ -21,9 +21,6 @@ public class CreatePetitionAcceptanceTest extends AcceptanceTest {
     @Autowired
     PetitionRepository petitionRepository;
 
-    @Autowired
-    UserRepository userRepository;
-
     @Test
     void createPetitionByNormal() {
         KOSE.doSignUp();

--- a/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
@@ -31,7 +31,7 @@ public class ReleasePetitionAcceptanceTest extends AcceptanceTest {
 
     @Test
     @DisplayName("청원을 만들고 5명이 동의해서 Manager가 release하는 테스트")
-    void ReleasePetition() {
+    void releasePetition() {
         EUNGI.doSignUp();
 
         PetitionRequest petitionRequest = new PetitionRequest("title", "description", Category.ACADEMIC.getId());
@@ -61,7 +61,7 @@ public class ReleasePetitionAcceptanceTest extends AcceptanceTest {
             TempPetitionResponse petitionResponse = petition.as(TempPetitionResponse.class);
             Long petitionId = petitionResponse.getId();
             AgreementRequest agreementRequest = new AgreementRequest("동의합니다. ");
-            tUser.doLoginAndThen().agreePetition(agreementRequest, petitionId);
+            tUser.doLoginAndThen().agreePetitionWith(agreementRequest, petitionId);
         }
     }
 

--- a/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
@@ -8,7 +8,6 @@ import com.gistpetition.api.petition.domain.PetitionRepository;
 import com.gistpetition.api.petition.dto.AgreementRequest;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.petition.dto.TempPetitionResponse;
-import com.gistpetition.api.user.domain.UserRole;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,11 +44,10 @@ public class ReleasePetitionAcceptanceTest extends AcceptanceTest {
 
         agreePetitionByFiveUsers(tmpUrl);
 
-        GUNE.doSignUp();
-        Response petition = T_ADMIN.doLoginAndThen().updateUserRoleAndThen(GUNE, UserRole.MANAGER).retrieveTempPetition(tmpUrl);
+        Response petition = T_MANAGER.doLoginAndThen().retrieveTempPetition(tmpUrl);
         TempPetitionResponse willBeReleasedPetition = petition.as(TempPetitionResponse.class);
 
-        GUNE.doLoginAndThen().releasePetition(willBeReleasedPetition.getId());
+        T_MANAGER.doLoginAndThen().releasePetition(willBeReleasedPetition.getId());
 
         Response releasedPetition = EUNGI.doLoginAndThen().retrieveReleasedPetition(willBeReleasedPetition.getId());
         assertThat(releasedPetition.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
@@ -1,6 +1,82 @@
 package com.gistpetition.api.acceptance.petition;
 
 import com.gistpetition.api.acceptance.AcceptanceTest;
+import com.gistpetition.api.acceptance.common.TUser;
+import com.gistpetition.api.petition.domain.AgreementRepository;
+import com.gistpetition.api.petition.domain.Category;
+import com.gistpetition.api.petition.domain.PetitionRepository;
+import com.gistpetition.api.petition.dto.AgreementRequest;
+import com.gistpetition.api.petition.dto.PetitionRequest;
+import com.gistpetition.api.petition.dto.TempPetitionResponse;
+import com.gistpetition.api.user.domain.UserRole;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import static com.gistpetition.api.acceptance.common.TUser.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReleasePetitionAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    PetitionRepository petitionRepository;
+
+    @Autowired
+    AgreementRepository agreementRepository;
+
+    @Test
+    void test() {
+        for (TUser tUser : values()) {
+            if (!tUser.name().equals("T_ADMIN")) {
+                tUser.doSignUp();
+                System.out.println(tUser.getId());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("청원을 만들고")
+    void ReleasePetition() {
+        EUNGI.doSignUp();
+
+        PetitionRequest petitionRequest = new PetitionRequest("title", "description", Category.ACADEMIC.getId());
+        Response createdPetition = EUNGI.doLoginAndThen().createPetition(petitionRequest);
+
+        assertThat(createdPetition.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        String[] locationHeader = createdPetition.header(HttpHeaders.LOCATION).split("/");
+        String tmpUrl = locationHeader[locationHeader.length - 1];
+
+        for (TUser tUser : willAgreeUserArray()) {
+            tUser.doSignUp();
+            Response petition = tUser.doLoginAndThen().retrieveTempPetition(tmpUrl);
+            TempPetitionResponse petitionResponse = petition.as(TempPetitionResponse.class);
+            Long petitionId = petitionResponse.getId();
+
+            AgreementRequest agreementRequest = new AgreementRequest("동의합니다. ");
+            Response response = tUser.doLoginAndThen().agreePetition(agreementRequest, petitionId);
+        }
+
+        Response petition = T_ADMIN.doLoginAndThen().updateUserRoleAndThen(EUNGI, UserRole.MANAGER).retrieveTempPetition(tmpUrl);
+        TempPetitionResponse response = petition.as(TempPetitionResponse.class);
+
+        Response releasedPetition = T_ADMIN.doLoginAndThen().releasePetition(response.getId());
+
+        EUNGI.doLoginAndThen().retrieveTempPetition(tmpUrl).as(TempPetitionResponse.class);
+
+
+    }
+
+    @AfterEach
+    void tearDown() {
+        TUser.clearAll();
+        agreementRepository.deleteAllInBatch();
+        petitionRepository.deleteAllInBatch();
+    }
+
+
 }

--- a/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
+++ b/src/test/java/com/gistpetition/api/acceptance/petition/ReleasePetitionAcceptanceTest.java
@@ -1,0 +1,6 @@
+package com.gistpetition.api.acceptance.petition;
+
+import com.gistpetition.api.acceptance.AcceptanceTest;
+
+public class ReleasePetitionAcceptanceTest extends AcceptanceTest {
+}


### PR DESCRIPTION
청원 생성 후 5명이 동의하고 Manager가 release하는 테스트를 작성했습니다. Manager 권한이 필요한 작업이 중복되는 경우가 많아 Manger 권한의 User를 TestDataLoader를 통해 주입하는 것도 좋은 방법일 것 같습니다. 지금은 통일성을 위해서 Test에서 Manager 권한을 Admin을 통해 주입했습니다. 이후 인수테스트 리펙토링을 진행해보면 좋겠습니다!

Close #222 