### PR TITLE
feat: 만료된 청원 조회 기능 구현

### DIFF
--- a/src/main/java/com/gistpetition/api/common/persistence/BaseEntity.java
+++ b/src/main/java/com/gistpetition/api/common/persistence/BaseEntity.java
@@ -12,9 +12,9 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     protected BaseEntity() {
     }

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -57,32 +57,22 @@ public class PetitionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedPetition(Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByReleasedTrue(pageable));
-    }
-
-    @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedPetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndReleasedTrue(Category.of(categoryId), pageable));
-    }
-
-    @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(31), pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(31), pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedAndNotExpiredPetition(Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveOngoingPetition(Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime.now().minusDays(30), pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveReleasedAndNotExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveOngoingPetitionByCategoryId(Long categoryId, Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(30), pageable));
     }
 

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_ANSWER;
-import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_RELEASE;
+
+import static com.gistpetition.api.petition.domain.Petition.*;
 
 @Service
 @RequiredArgsConstructor
@@ -58,22 +58,22 @@ public class PetitionService {
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveExpiredPetition(Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(31), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(31), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveOngoingPetition(Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime.now().minusDays(30), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveOngoingPetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(30), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -57,12 +57,12 @@ public class PetitionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 
     @Transactional(readOnly = true)
-    public Page<PetitionPreviewResponse> retrieveExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
     }
 

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -18,6 +18,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT;
 
 @Service
@@ -62,6 +64,26 @@ public class PetitionService {
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveReleasedPetitionByCategoryId(Long categoryId, Pageable pageable) {
         return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndReleasedTrue(Category.of(categoryId), pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(31), pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(31), pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PetitionPreviewResponse> retrieveReleasedAndNotExpiredPetition(Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime.now().minusDays(30), pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PetitionPreviewResponse> retrieveReleasedAndNotExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(30), pageable));
     }
 
     @Transactional(readOnly = true)
@@ -183,4 +205,6 @@ public class PetitionService {
     private Petition findPetitionById(Long petitionId) {
         return petitionRepository.findById(petitionId).orElseThrow(NoSuchPetitionException::new);
     }
+
+
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -19,6 +19,7 @@ import java.util.List;
 public class Petition extends BaseEntity {
 
     public static final int REQUIRED_AGREEMENT = 5;
+    public static final int POSTING_PERIOD = 30;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -10,6 +10,7 @@ import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,5 +103,10 @@ public class Petition extends BaseEntity {
 
     public boolean isAnswered() {
         return answered;
+    }
+
+    public boolean isExpiredAt(LocalDateTime time) {
+        LocalDateTime expirationDate = this.createdAt.plusDays(POSTING_PERIOD);
+        return expirationDate.isBefore(time);
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -22,6 +22,7 @@ public class Petition extends BaseEntity {
 
     public static final int REQUIRED_AGREEMENT_FOR_RELEASE = 5;
     public static final int REQUIRED_AGREEMENT_FOR_ANSWER = 20;
+    public static final int POSTING_PERIOD = 30;
   
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.history.RevisionRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -29,6 +30,14 @@ public interface PetitionRepository extends RevisionRepository<Petition, Long, L
     Page<Petition> findAllByOrderByAgreeCountDesc(Pageable pageable);
 
     Page<Petition> findPetitionByAgreeCountIsGreaterThanEqualAndReleasedFalse(int requiredAgreeCount, Pageable pageable);
+
+    Page<Petition> findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime time, Pageable pageable);
+
+    Page<Petition> findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category category, LocalDateTime time, Pageable pageable);
+
+    Page<Petition> findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime time, Pageable pageable);
+
+    Page<Petition> findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category category, LocalDateTime time, Pageable pageable);
 
     Long countByReleasedTrue();
 

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -14,6 +14,7 @@ public class PetitionPreviewResponse {
     private final Integer agreements;
     private final LocalDateTime createdAt;
     private final String tempUrl;
+    private final Boolean expired;
 
     public static PetitionPreviewResponse of(Petition petition) {
         return new PetitionPreviewResponse(
@@ -22,7 +23,8 @@ public class PetitionPreviewResponse {
                 petition.getCategory().getName(),
                 petition.getAgreeCount(),
                 petition.getCreatedAt(),
-                petition.getTempUrl()
+                petition.getTempUrl(),
+                petition.isExpiredAt(LocalDateTime.now())
         );
     }
 

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
@@ -20,6 +20,7 @@ public class PetitionResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String tempUrl;
+    private Boolean expired;
 
     public static PetitionResponse of(Petition petition) {
         return new PetitionResponse(
@@ -31,7 +32,8 @@ public class PetitionResponse {
                 petition.getAgreeCount(),
                 petition.getCreatedAt(),
                 petition.getUpdatedAt(),
-                petition.getTempUrl()
+                petition.getTempUrl(),
+                petition.isExpiredAt(LocalDateTime.now())
         );
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -46,9 +46,9 @@ public class PetitionController {
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedAndExpiredPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
-            return ResponseEntity.ok().body(petitionService.retrieveExpiredPetition(pageable));
+            return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionService.retrieveExpiredPetitionByCategoryId(categoryId, pageable));
+        return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
     @GetMapping("/petitions/all")

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -37,9 +37,18 @@ public class PetitionController {
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
-            return ResponseEntity.ok().body(petitionService.retrieveReleasedPetition(pageable));
+            return ResponseEntity.ok().body(petitionService.retrieveReleasedAndNotExpiredPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionService.retrieveReleasedPetitionByCategoryId(categoryId, pageable));
+        return ResponseEntity.ok().body(petitionService.retrieveReleasedAndNotExpiredPetitionByCategoryId(categoryId, pageable));
+    }
+
+    @GetMapping("/petitions/expired")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedAndExpiredPetitions(@RequestParam(defaultValue = "0") Long categoryId,
+                                                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        if (categoryId.equals(0L)) {
+            return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetition(pageable));
+        }
+        return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
     @GetMapping("/petitions/all")

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -37,18 +37,18 @@ public class PetitionController {
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
-            return ResponseEntity.ok().body(petitionService.retrieveReleasedAndNotExpiredPetition(pageable));
+            return ResponseEntity.ok().body(petitionService.retrieveOngoingPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionService.retrieveReleasedAndNotExpiredPetitionByCategoryId(categoryId, pageable));
+        return ResponseEntity.ok().body(petitionService.retrieveOngoingPetitionByCategoryId(categoryId, pageable));
     }
 
     @GetMapping("/petitions/expired")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedAndExpiredPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
-            return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetition(pageable));
+            return ResponseEntity.ok().body(petitionService.retrieveExpiredPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
+        return ResponseEntity.ok().body(petitionService.retrieveExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
     @GetMapping("/petitions/all")

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -290,7 +290,7 @@ public class PetitionServiceTest extends ServiceTest {
         }
         releasePetitionByIds(createdPetitionIds);
 
-        Page<PetitionPreviewResponse> expiredPetitions = petitionService.retrieveExpiredPetition(PageRequest.of(0, 10));
+        Page<PetitionPreviewResponse> expiredPetitions = petitionService.retrieveReleasedAndExpiredPetition(PageRequest.of(0, 10));
         assertThat(expiredPetitions.getContent()).hasSize(numOfPetition);
 
         for (PetitionPreviewResponse ep : expiredPetitions) {

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -15,10 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.auditing.AuditingHandler;
-import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -41,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 
 public class PetitionServiceTest extends ServiceTest {
     private static final PetitionRequest DORM_PETITION_REQUEST = new PetitionRequest("title", "description", Category.DORMITORY.getId());
@@ -63,19 +60,12 @@ public class PetitionServiceTest extends ServiceTest {
 
     @SpyBean
     private AuditingHandler auditingHandler;
-    @MockBean
-    private DateTimeProvider dateTimeProvider;
 
     private User petitionOwner;
     private final List<User> users = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
-        when(dateTimeProvider.getNow()).thenAnswer(
-                i -> Optional.of(LocalDateTime.now())
-        );
-        auditingHandler.setDateTimeProvider(dateTimeProvider);
-
         petitionOwner = userRepository.save(new User(EMAIL, PASSWORD, UserRole.USER));
         for (int i = 0; i < 5; i++) {
             String email = String.format("email%2s@gist.ac.kr", i);
@@ -281,7 +271,9 @@ public class PetitionServiceTest extends ServiceTest {
     @Test
     void retrieveExpiredPetition() {
         LocalDateTime pastTime = LocalDateTime.of(2020, 12, 1, 0, 0);
-        when(dateTimeProvider.getNow()).thenReturn(Optional.of(pastTime));
+        auditingHandler.setDateTimeProvider(
+                () -> Optional.of(pastTime)
+        );
 
         int numOfPetition = 3;
         List<Long> createdPetitionIds = new ArrayList<>();

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -55,10 +55,15 @@ public class PetitionServiceTest extends ServiceTest {
     private HttpSession httpSession;
 
     private User petitionOwner;
+    private final List<User> users = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
         petitionOwner = userRepository.save(new User(EMAIL, PASSWORD, UserRole.USER));
+        for (int i = 0; i < 5; i++) {
+            String email = String.format("email%2s@gist.ac.kr", i);
+            users.add(userRepository.save(new User(email, PASSWORD, UserRole.USER)));
+        }
     }
 
     @Test
@@ -251,6 +256,15 @@ public class PetitionServiceTest extends ServiceTest {
         Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         Petition petition = petitionRepository.findById(petitionId).orElseThrow();
         assertFalse(petition.isExpiredAt(LocalDateTime.now().minusDays(31)));
+    }
+
+    private void releasePetitionByIds(List<Long> ids) {
+        for (Long id : ids) {
+            for (int i = 0; i < 5; i++) {
+                petitionService.agree(AGREEMENT_REQUEST, id, users.get(i).getId());
+            }
+            petitionService.releasePetition(id);
+        }
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -239,6 +239,21 @@ public class PetitionServiceTest extends ServiceTest {
     }
 
     @Test
+    void retrieveOngoingPetition() {
+        petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
+        petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
+        Page<PetitionPreviewResponse> petitions = petitionService.retrieveOngoingPetition(PageRequest.of(0, 10));
+        petitions.getContent().forEach(petitionPreviewResponse -> assertFalse(petitionPreviewResponse.getExpired()));
+    }
+
+    @Test
+    void retrieveExpiredPetition() {
+        Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
+        Petition petition = petitionRepository.findById(petitionId).orElseThrow();
+        assertFalse(petition.isExpiredAt(LocalDateTime.now().minusDays(31)));
+    }
+
+    @Test
     void getStateOfAgreement() {
         Long petitionId = petitionService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         assertThat(petitionService.retrieveStateOfAgreement(petitionId, petitionOwner.getId())).isFalse();


### PR DESCRIPTION
사용자에게 보여지는 청원을 진행중인 청원/ 만료된 청원으로 구분하도록 하였습니다.
/petitions로 접근하면 진행중인 청원들이,
/petitions/expired로 접근하면 만료된 청원들이 조회됩니다.

진행중인 청원과 만료된 청원 모두 카테고리 별 조회가 가능하도록 했습니다.

또한 petition의 응답으로 expired 여부도 넘겨주도록 했습니다.

close #177 