### PR TITLE
feat: 도메인과 DB 레이어를 분리한다.

### DIFF
--- a/src/main/java/com/gistpetition/api/answer/domain/Answer.java
+++ b/src/main/java/com/gistpetition/api/answer/domain/Answer.java
@@ -4,15 +4,14 @@ import com.gistpetition.api.common.persistence.BaseEntity;
 import lombok.Getter;
 import org.hibernate.envers.Audited;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
 
 @Audited
 @Entity
 @Getter
 public class Answer extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
     @Lob
     private String content;
     @Column(unique = true)
@@ -22,11 +21,6 @@ public class Answer extends BaseEntity {
     }
 
     public Answer(String content, Long petitionId) {
-        this(null, content, petitionId);
-    }
-
-    public Answer(Long id, String content, Long petitionId) {
-        this.id = id;
         this.content = content;
         this.petitionId = petitionId;
     }

--- a/src/main/java/com/gistpetition/api/common/persistence/BaseEntity.java
+++ b/src/main/java/com/gistpetition/api/common/persistence/BaseEntity.java
@@ -1,22 +1,29 @@
 package com.gistpetition.api.common.persistence;
 
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     @CreatedDate
     protected LocalDateTime createdAt;
     @LastModifiedDate
     protected LocalDateTime updatedAt;
 
     protected BaseEntity() {
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/gistpetition/api/common/persistence/UnmodifiableEntity.java
+++ b/src/main/java/com/gistpetition/api/common/persistence/UnmodifiableEntity.java
@@ -3,17 +3,24 @@ package com.gistpetition.api.common.persistence;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class UnmodifiableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @CreatedDate
     private LocalDateTime createdAt;
 
     protected UnmodifiableEntity() {
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/gistpetition/api/exception/petition/ExpiredPetitionException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/ExpiredPetitionException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class ExpiredPetitionException extends PetitionException {
+    private static final String MESSAGE = "만료된 청원입니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public ExpiredPetitionException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -41,6 +41,7 @@ public class PetitionService {
                         petitionRequest.getTitle(),
                         petitionRequest.getDescription(),
                         Category.of(petitionRequest.getCategoryId()),
+                        LocalDateTime.now().plusDays(POSTING_PERIOD),
                         userId,
                         tempUrl));
         return created.getId();
@@ -184,7 +185,7 @@ public class PetitionService {
     @Transactional
     public void releasePetition(Long petitionId) {
         Petition petition = findPetitionById(petitionId);
-        petition.release();
+        petition.release(LocalDateTime.now());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -154,7 +154,7 @@ public class PetitionService {
         Petition petition = findPetitionById(petitionId);
         User user = findUserById(userId);
         Agreement agreement = new Agreement(request.getDescription(), user.getId());
-        agreement.setPetition(petition);
+        agreement.setPetition(petition, LocalDateTime.now());
         try {
             agreementRepository.save(agreement);
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -4,6 +4,7 @@ import com.gistpetition.api.common.persistence.UnmodifiableEntity;
 import lombok.Getter;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -37,9 +38,9 @@ public class Agreement extends UnmodifiableEntity {
         return this.userId.equals(userId);
     }
 
-    public void setPetition(Petition petition) {
+    public void setPetition(Petition petition, LocalDateTime at) {
         this.petition = petition;
-        petition.addAgreement(this);
+        petition.addAgreement(this, at);
     }
 
     @Override

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -4,15 +4,13 @@ import com.gistpetition.api.common.persistence.UnmodifiableEntity;
 import lombok.Getter;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Getter
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "petition_id"}))
 public class Agreement extends UnmodifiableEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
     @Lob
     private String description;
     @Column(name = "user_id")
@@ -26,21 +24,14 @@ public class Agreement extends UnmodifiableEntity {
     }
 
     public Agreement(String description, Long userId) {
-        this(null, description, userId, null);
+        this(description, userId, null);
     }
 
-    public Agreement(String description, Long userId, Petition petition) {
-        this(null, description, userId, petition);
-    }
-
-
-    private Agreement(Long id, String description, Long userId, Petition petition) {
-        this.id = id;
+    private Agreement(String description, Long userId, Petition petition) {
         this.description = description;
         this.userId = userId;
         this.petition = petition;
     }
-
 
     public boolean writtenBy(Long userId) {
         return this.userId.equals(userId);
@@ -49,5 +40,18 @@ public class Agreement extends UnmodifiableEntity {
     public void setPetition(Petition petition) {
         this.petition = petition;
         petition.addAgreement(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Agreement agreement = (Agreement) o;
+        return Objects.equals(userId, agreement.userId) && Objects.equals(petition, agreement.petition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, petition);
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -1,10 +1,12 @@
 package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.common.persistence.BaseEntity;
-import com.gistpetition.api.exception.petition.*;
+import com.gistpetition.api.exception.petition.AlreadyReleasedPetitionException;
+import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
+import com.gistpetition.api.exception.petition.ExpiredPetitionException;
+import com.gistpetition.api.exception.petition.NotEnoughAgreementException;
 import com.gistpetition.api.user.domain.User;
 import lombok.Getter;
-import org.apache.tomcat.jni.Local;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
@@ -57,12 +59,11 @@ public class Petition extends BaseEntity {
         this.tempUrl = tempUrl;
     }
 
-    public void addAgreement(Agreement newAgreement) {
+    public void addAgreement(Agreement newAgreement, LocalDateTime at) {
         if (agreements.contains(newAgreement)) {
             throw new DuplicatedAgreementException();
         }
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isAfter(expiredAt)) {
+        if (at.isAfter(expiredAt)) {
             throw new ExpiredPetitionException();
         }
         this.agreements.add(newAgreement);

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -2,6 +2,8 @@ package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.common.persistence.BaseEntity;
 import com.gistpetition.api.exception.petition.AlreadyReleasedPetitionException;
+import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
+import com.gistpetition.api.exception.petition.DuplicatedAnswerException;
 import com.gistpetition.api.exception.petition.NotEnoughAgreementException;
 import com.gistpetition.api.user.domain.User;
 import lombok.Getter;
@@ -18,18 +20,12 @@ import java.util.List;
 @Getter
 @Entity
 public class Petition extends BaseEntity {
-
-
     public static final int REQUIRED_AGREEMENT_FOR_RELEASE = 5;
     public static final int REQUIRED_AGREEMENT_FOR_ANSWER = 20;
     public static final int POSTING_PERIOD = 30;
-  
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+
     private String title;
-    @Column(unique = true)
-    private String tempUrl;
+
     @Lob
     private String description;
     @Enumerated(EnumType.STRING)
@@ -37,6 +33,8 @@ public class Petition extends BaseEntity {
     private Boolean answered = false;
     private Boolean released = false;
     private Long userId;
+    @Column(unique = true)
+    private String tempUrl;
     @NotAudited
     private Integer agreeCount = 0;
     @NotAudited
@@ -48,19 +46,17 @@ public class Petition extends BaseEntity {
     }
 
     public Petition(String title, String description, Category category, Long userId, String tempUrl) {
-        this(null, title, tempUrl, description, category, userId);
-    }
-
-    private Petition(Long id, String title, String tempUrl, String description, Category category, Long userId) {
-        this.id = id;
         this.title = title;
-        this.tempUrl = tempUrl;
         this.description = description;
         this.category = category;
         this.userId = userId;
+        this.tempUrl = tempUrl;
     }
 
     public void addAgreement(Agreement newAgreement) {
+        if (agreements.contains(newAgreement)) {
+            throw new DuplicatedAgreementException();
+        }
         this.agreements.add(newAgreement);
         this.agreeCount += 1;
     }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -59,7 +59,7 @@ public class Petition extends BaseEntity {
         if (agreements.contains(newAgreement)) {
             throw new DuplicatedAgreementException();
         }
-        if (at.isAfter(expiredAt)) {
+        if (isExpiredAt(at)) {
             throw new ExpiredPetitionException();
         }
         this.agreements.add(newAgreement);
@@ -76,7 +76,7 @@ public class Petition extends BaseEntity {
     }
 
     public void release(LocalDateTime at) {
-        if (at.isAfter(expiredAt)) {
+        if (isExpiredAt(at)) {
             throw new ExpiredPetitionException();
         }
         if (released) {
@@ -113,6 +113,6 @@ public class Petition extends BaseEntity {
     }
 
     public boolean isExpiredAt(LocalDateTime time) {
-        return expiredAt.isBefore(time);
+        return time.isAfter(expiredAt);
     }
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -46,10 +46,6 @@ public class Petition extends BaseEntity {
     protected Petition() {
     }
 
-    public Petition(String title, String description, Category category, Long userId, String tempUrl) {
-        this(title, description, category, LocalDateTime.now().plusDays(POSTING_PERIOD), userId, tempUrl);
-    }
-
     public Petition(String title, String description, Category category, LocalDateTime expiredAt, Long userId, String tempUrl) {
         this.title = title;
         this.description = description;
@@ -79,7 +75,10 @@ public class Petition extends BaseEntity {
         return false;
     }
 
-    public void release() {
+    public void release(LocalDateTime at) {
+        if (at.isAfter(expiredAt)) {
+            throw new ExpiredPetitionException();
+        }
         if (released) {
             throw new AlreadyReleasedPetitionException();
         }

--- a/src/main/java/com/gistpetition/api/user/domain/User.java
+++ b/src/main/java/com/gistpetition/api/user/domain/User.java
@@ -2,13 +2,13 @@ package com.gistpetition.api.user.domain;
 
 import com.gistpetition.api.common.persistence.BaseEntity;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Entity
 public class User extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
     @Column(unique = true)
     private String username;
     private String password;
@@ -19,22 +19,9 @@ public class User extends BaseEntity {
     }
 
     public User(String username, String password, UserRole userRole) {
-        this(null, username, password, userRole);
-    }
-
-    public User(String username, String password, UserRole userRole, Boolean enabled) {
-        this(null, username, password, userRole);
-    }
-
-    public User(Long id, String username, String password, UserRole userRole) {
-        this.id = id;
         this.username = username;
         this.password = password;
         this.userRole = userRole;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getUsername() {
@@ -56,5 +43,4 @@ public class User extends BaseEntity {
     public void setUserRole(UserRole userRole) {
         this.userRole = userRole;
     }
-
 }

--- a/src/main/java/com/gistpetition/api/verification/domain/VerificationInfo.java
+++ b/src/main/java/com/gistpetition/api/verification/domain/VerificationInfo.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 @Getter
 @MappedSuperclass
-public class VerificationInfo {
+public abstract class VerificationInfo {
     public static final int CONFIRM_CODE_EXPIRE_MINUTE = 1;
     public static final int CONFIRMATION_EXPIRE_MINUTE = 5;
 

--- a/src/test/java/com/gistpetition/api/answer/AnswerServiceTest.java
+++ b/src/test/java/com/gistpetition/api/answer/AnswerServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.history.RevisionMetadata;
 
 import javax.servlet.http.HttpSession;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -69,7 +70,7 @@ class AnswerServiceTest extends ServiceTest {
         user = userRepository.save(new User("normal@email.com", "password", UserRole.USER));
         manager = userRepository.save(new User("manager@email.com", "password", UserRole.MANAGER));
         httpSession.setAttribute("user", new SimpleUser(manager));
-        savedPetition = petitionRepository.save(new Petition("title", "description", Category.DORMITORY, user.getId(), TEMP_URL));
+        savedPetition = petitionRepository.save(new Petition("title", "description", Category.DORMITORY, LocalDateTime.now(), user.getId(), TEMP_URL));
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/PetitionBuilder.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionBuilder.java
@@ -1,0 +1,64 @@
+package com.gistpetition.api.petition;
+
+import com.gistpetition.api.petition.domain.Category;
+import com.gistpetition.api.petition.domain.Petition;
+
+import java.time.LocalDateTime;
+
+public final class PetitionBuilder {
+    private Boolean answered = false;
+    private String title = "제목";
+    private String description = "내용";
+    private Category category = Category.DORMITORY;
+    private LocalDateTime expiredAt = LocalDateTime.now().plusDays(Petition.POSTING_PERIOD);
+    private Long userId;
+    private String tempUrl;
+
+    private PetitionBuilder() {
+    }
+
+    public static PetitionBuilder aPetition() {
+        return new PetitionBuilder();
+    }
+
+    public PetitionBuilder withAnswered(Boolean answered) {
+        this.answered = answered;
+        return this;
+    }
+
+    public PetitionBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public PetitionBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public PetitionBuilder withCategory(Category category) {
+        this.category = category;
+        return this;
+    }
+
+    public PetitionBuilder withExpiredAt(LocalDateTime expiredAt) {
+        this.expiredAt = expiredAt;
+        return this;
+    }
+
+    public PetitionBuilder withUserId(Long userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public PetitionBuilder withTempUrl(String tempUrl) {
+        this.tempUrl = tempUrl;
+        return this;
+    }
+
+    public Petition build() {
+        Petition petition = new Petition(title, description, category, expiredAt, userId, tempUrl);
+        petition.setAnswered(answered);
+        return petition;
+    }
+}

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -15,23 +15,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PetitionTest {
     private static final String AGREEMENT_DESCRIPTION = "동의합니다.";
-    private static final String EMAIL = "email@gist.ac.kr";
-    private static final String PASSWORD = "password";
     private static final String TEMP_URL = "AAAAAA";
 
-    private User user;
     private Petition petition;
 
     @BeforeEach
     void setUp() {
-        user = new User(1L, EMAIL, PASSWORD, UserRole.USER);
-        petition = new Petition("title", "description", Category.DORMITORY, user.getId(), TEMP_URL);
+        petition = new Petition("title", "description", Category.DORMITORY, 1L, TEMP_URL);
     }
 
     @Test
     void agree() {
         assertThat(petition.getAgreements()).hasSize(0);
-        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, user.getId());
+        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, 1L);
         petition.addAgreement(agreement);
         assertThat(petition.getAgreements()).hasSize(1);
         assertThat(petition.getAgreeCount()).isEqualTo(1);
@@ -39,11 +35,9 @@ class PetitionTest {
 
     @Test
     void agreeByMultipleUser() {
-        User user1 = new User(2L, EMAIL, PASSWORD, UserRole.USER);
-        User user2 = new User(3L, EMAIL, PASSWORD, UserRole.USER);
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user.getId()));
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user1.getId()));
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, user2.getId()));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 2L));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 3L));
         assertThat(petition.getAgreements()).hasSize(3);
         assertThat(petition.getAgreeCount()).isEqualTo(3);
     }
@@ -51,8 +45,7 @@ class PetitionTest {
     @Test
     void release() {
         LongStream.range(0, 5)
-                .mapToObj(i -> new User(i, i + EMAIL, PASSWORD, UserRole.USER))
-                .forEach(u -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, u.getId())));
+                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId)));
 
         petition.release();
 
@@ -62,8 +55,7 @@ class PetitionTest {
     @Test
     void releaseAlreadyReleased() {
         LongStream.range(0, 5)
-                .mapToObj(i -> new User(i, i + EMAIL, PASSWORD, UserRole.USER))
-                .forEach(u -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, u.getId())));
+                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId)));
         petition.release();
 
         assertThatThrownBy(() -> petition.release()).isInstanceOf(AlreadyReleasedPetitionException.class);

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -1,12 +1,15 @@
 package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.exception.petition.AlreadyReleasedPetitionException;
+import com.gistpetition.api.exception.petition.ExpiredPetitionException;
 import com.gistpetition.api.exception.petition.NotEnoughAgreementException;
+import com.gistpetition.api.petition.PetitionBuilder;
 import com.gistpetition.api.user.domain.User;
 import com.gistpetition.api.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +43,15 @@ class PetitionTest {
         petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 3L));
         assertThat(petition.getAgreements()).hasSize(3);
         assertThat(petition.getAgreeCount()).isEqualTo(3);
+    }
+
+    @Test
+    void agreeExpiredPetition() {
+        LocalDateTime past = LocalDateTime.MIN;
+        Petition expiredPetition = PetitionBuilder.aPetition().withExpiredAt(past).build();
+        assertThatThrownBy(() ->
+                expiredPetition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L))
+        ).isInstanceOf(ExpiredPetitionException.class);
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -4,8 +4,6 @@ import com.gistpetition.api.exception.petition.AlreadyReleasedPetitionException;
 import com.gistpetition.api.exception.petition.ExpiredPetitionException;
 import com.gistpetition.api.exception.petition.NotEnoughAgreementException;
 import com.gistpetition.api.petition.PetitionBuilder;
-import com.gistpetition.api.user.domain.User;
-import com.gistpetition.api.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +15,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PetitionTest {
+    public static final LocalDateTime PETITION_CREATION_AT = LocalDateTime.of(2002, 2, 2, 2, 2);
+    public static final LocalDateTime PETITION_ONGOING_AT = PETITION_CREATION_AT.plusDays(Petition.POSTING_PERIOD / 2);
+    public static final LocalDateTime PETITION_EXPIRED_AT = PETITION_CREATION_AT.plusDays(Petition.POSTING_PERIOD);
     private static final String AGREEMENT_DESCRIPTION = "동의합니다.";
     private static final String TEMP_URL = "AAAAAA";
 
@@ -24,40 +25,45 @@ class PetitionTest {
 
     @BeforeEach
     void setUp() {
-        petition = new Petition("title", "description", Category.DORMITORY, 1L, TEMP_URL);
+        petition = PetitionBuilder.aPetition().withExpiredAt(PETITION_EXPIRED_AT).withTempUrl(TEMP_URL).build();
     }
 
     @Test
     void agree() {
         assertThat(petition.getAgreements()).hasSize(0);
         Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, 1L);
-        petition.addAgreement(agreement);
+        petition.addAgreement(agreement, PETITION_ONGOING_AT);
         assertThat(petition.getAgreements()).hasSize(1);
         assertThat(petition.getAgreeCount()).isEqualTo(1);
     }
 
     @Test
     void agreeByMultipleUser() {
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L));
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 2L));
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 3L));
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L), PETITION_ONGOING_AT);
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 2L), PETITION_ONGOING_AT);
+        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 3L), PETITION_ONGOING_AT);
         assertThat(petition.getAgreements()).hasSize(3);
         assertThat(petition.getAgreeCount()).isEqualTo(3);
     }
 
     @Test
     void agreeExpiredPetition() {
-        LocalDateTime past = LocalDateTime.MIN;
-        Petition expiredPetition = PetitionBuilder.aPetition().withExpiredAt(past).build();
+//        LocalDateTime past = LocalDateTime.MIN;
+//        LocalDateTime future = LocalDateTime.MAX;
+//        Petition expiredPetition = PetitionBuilder.aPetition().withExpiredAt(past).build();
+//        assertThatThrownBy(() ->
+//                expiredPetition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L), future)
+//        ).isInstanceOf(ExpiredPetitionException.class);
+
         assertThatThrownBy(() ->
-                expiredPetition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L))
+                petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L), PETITION_EXPIRED_AT.plusDays(1))
         ).isInstanceOf(ExpiredPetitionException.class);
     }
 
     @Test
     void release() {
         LongStream.range(0, 5)
-                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId)));
+                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId), PETITION_ONGOING_AT));
 
         petition.release();
 
@@ -67,10 +73,11 @@ class PetitionTest {
     @Test
     void releaseAlreadyReleased() {
         LongStream.range(0, 5)
-                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId)));
+                .forEach(userId -> petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId), PETITION_ONGOING_AT));
         petition.release();
 
-        assertThatThrownBy(() -> petition.release()).isInstanceOf(AlreadyReleasedPetitionException.class);
+        assertThatThrownBy(() -> petition.release()
+        ).isInstanceOf(AlreadyReleasedPetitionException.class);
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/verification/SignUpVerificationServiceTest.java
+++ b/src/test/java/com/gistpetition/api/verification/SignUpVerificationServiceTest.java
@@ -51,7 +51,7 @@ class SignUpVerificationServiceTest extends ServiceTest {
 
     @Test
     void createVerificationCodeFailedIfAlreadyExisted() {
-        userRepository.save(new User(GIST_EMAIL, PASSWORD, UserRole.USER, true));
+        userRepository.save(new User(GIST_EMAIL, PASSWORD, UserRole.USER));
         assertThatThrownBy(
                 () -> signUpVerificationService.createVerificationInfo(new VerificationEmailRequest(GIST_EMAIL))
         ).isInstanceOf(DuplicatedUserException.class);


### PR DESCRIPTION
close #241 
close #240 
close #239 

Petition 도메인에 expiredAt 을 추가하여 관리하는 작업으로 시작.
DB종속적인 CreatedAt 이 비즈니스 로직에 관여하는것이 어색하다 판단, BaseEntity 에 Id 까지 추가하여 도메인 로직과 DB종속 필드를 완전분리.
도메인 메서드 중 만료된 청원에 관련한 예외와 로직 추가 (agree, release)
이에따른 테스트 수정. 테스트하기 좋은 코드를 위해 시간 의존성을 도메인에서 분리함 (LocalDateTime.now() 를 도메인로직에서 사용하지 않도록 함)

---

한번에 많은 부분을 변경함.
상세히 읽어보시고, 리뷰 남겨주길 바람.