### PR TITLE
refactor: /petitions/ongoing으로 접근시 공개된 청원중 답변되지 않은 청원들을 불러오도록 함.

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionService.java
@@ -59,22 +59,22 @@ public class PetitionService {
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByExpiredAtBeforeAndReleasedTrue(LocalDateTime.now(), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndExpiredAtBeforeAndReleasedTrue(Category.of(categoryId), LocalDateTime.now(), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveOngoingPetition(Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByExpiredAtAfterAndReleasedTrueAndAnsweredFalse(LocalDateTime.now(), pageable));
     }
 
     @Transactional(readOnly = true)
     public Page<PetitionPreviewResponse> retrieveOngoingPetitionByCategoryId(Long categoryId, Pageable pageable) {
-        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category.of(categoryId), LocalDateTime.now().minusDays(POSTING_PERIOD), pageable));
+        return PetitionPreviewResponse.pageOf(petitionRepository.findAllByCategoryAndExpiredAtAfterAndReleasedTrueAndAnsweredFalse(Category.of(categoryId), LocalDateTime.now(), pageable));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/PetitionRepository.java
@@ -17,11 +17,7 @@ public interface PetitionRepository extends RevisionRepository<Petition, Long, L
 
     Page<Petition> findAllByCategory(Category category, Pageable pageable);
 
-    Page<Petition> findAllByCategoryAndReleasedTrue(Category category, Pageable pageable);
-
     Page<Petition> findAll(Pageable pageable);
-
-    Page<Petition> findAllByReleasedTrue(Pageable pageable);
 
     Page<Petition> findByTitleContains(String keyword, Pageable pageable);
 
@@ -31,13 +27,13 @@ public interface PetitionRepository extends RevisionRepository<Petition, Long, L
 
     Page<Petition> findPetitionByAgreeCountIsGreaterThanEqualAndReleasedFalse(int requiredAgreeCount, Pageable pageable);
 
-    Page<Petition> findAllByCreatedAtBeforeAndReleasedTrue(LocalDateTime time, Pageable pageable);
+    Page<Petition> findAllByExpiredAtBeforeAndReleasedTrue(LocalDateTime at, Pageable pageable);
 
-    Page<Petition> findAllByCategoryAndCreatedAtBeforeAndReleasedTrue(Category category, LocalDateTime time, Pageable pageable);
+    Page<Petition> findAllByCategoryAndExpiredAtBeforeAndReleasedTrue(Category category, LocalDateTime at, Pageable pageable);
 
-    Page<Petition> findAllByCreatedAtAfterAndReleasedTrue(LocalDateTime time, Pageable pageable);
+    Page<Petition> findAllByExpiredAtAfterAndReleasedTrueAndAnsweredFalse(LocalDateTime at, Pageable pageable);
 
-    Page<Petition> findAllByCategoryAndCreatedAtAfterAndReleasedTrue(Category category, LocalDateTime time, Pageable pageable);
+    Page<Petition> findAllByCategoryAndExpiredAtAfterAndReleasedTrueAndAnsweredFalse(Category category, LocalDateTime at, Pageable pageable);
   
     Page<Petition> findPetitionByAgreeCountIsGreaterThanEqualAndReleasedTrueAndAnsweredFalse(int requiredAnswerCount, Pageable pageable);
     

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -33,8 +33,8 @@ public class PetitionController {
         return ResponseEntity.created(URI.create("/petitions/temp/" + tempUrl)).build();
     }
 
-    @GetMapping("/petitions")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedPetitions(@RequestParam(defaultValue = "0") Long categoryId,
+    @GetMapping("/petitions/ongoing")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveOngoingPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
             return ResponseEntity.ok().body(petitionService.retrieveOngoingPetition(pageable));
@@ -51,6 +51,7 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
+    //@AdminPermissionRequired
     @GetMapping("/petitions/all")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveAllPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                               @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {


### PR DESCRIPTION
기존에는 /petitions 로 GET요청시 공개된 청원들을 모두 가져왔는데,
현재 우리 사이트에서는 공개된 청원들을 모두 모아서 보여주기 보다는,
공개된 청원들을 답변 안된 청원, 답변된 청원으로 나눠서 보여주므로,
그에 맞게 /petitions를 /petitions/ongoing으로 수정해서
해당 api로 접근 시 공개된 청원중 답변되지 않은 청원들을 불러오도록 refactoring했습니다.