### PR TITLE
refactor: Query,Command Controller 분리 및 api 권한 수정

### DIFF
--- a/src/main/java/com/gistpetition/api/answer/presentation/AnswerController.java
+++ b/src/main/java/com/gistpetition/api/answer/presentation/AnswerController.java
@@ -40,7 +40,7 @@ public class AnswerController {
         return ResponseEntity.ok().body(answerService.getNumberOfAnswers());
     }
 
-    @AdminPermissionRequired
+    @ManagerPermissionRequired
     @GetMapping("/answers/{answerId}/revisions")
     public ResponseEntity<Page<AnswerRevisionResponse>> retrieveAnswerRevisions(@PathVariable Long answerId, Pageable pageable) {
         return ResponseEntity.ok().body(answerService.retrieveRevisionsOfAnswer(answerId, pageable));

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionCommandController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionCommandController.java
@@ -1,0 +1,66 @@
+package com.gistpetition.api.petition.presentation;
+
+import com.gistpetition.api.config.annotation.AdminPermissionRequired;
+import com.gistpetition.api.config.annotation.LoginRequired;
+import com.gistpetition.api.config.annotation.LoginUser;
+import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
+import com.gistpetition.api.petition.application.PetitionService;
+import com.gistpetition.api.petition.dto.*;
+import com.gistpetition.api.user.domain.SimpleUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+public class PetitionCommandController {
+    private final PetitionService petitionService;
+
+    @LoginRequired
+    @PostMapping("/petitions")
+    public ResponseEntity<Void> createPetition(@Validated @RequestBody PetitionRequest petitionRequest,
+                                               @LoginUser SimpleUser simpleUser) {
+        Long createdPetitionId = petitionService.createPetition(petitionRequest, simpleUser.getId());
+        String tempUrl = petitionService.retrieveTempUrlOf(createdPetitionId);
+        return ResponseEntity.created(URI.create("/petitions/temp/" + tempUrl)).build();
+    }
+
+    @ManagerPermissionRequired
+    @PutMapping("/petitions/{petitionId}")
+    public ResponseEntity<Void> updatePetition(@PathVariable Long petitionId,
+                                               @Validated @RequestBody PetitionRequest changeRequest) {
+        petitionService.updatePetition(petitionId, changeRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ManagerPermissionRequired
+    @DeleteMapping("/petitions/{petitionId}")
+    public ResponseEntity<Void> deletePetition(@PathVariable Long petitionId) {
+        petitionService.deletePetition(petitionId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ManagerPermissionRequired
+    @PostMapping("/petitions/{petitionId}/release")
+    public ResponseEntity<Void> releasePetition(@PathVariable Long petitionId) {
+        petitionService.releasePetition(petitionId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @LoginRequired
+    @PostMapping("/petitions/{petitionId}/agreements")
+    public ResponseEntity<Void> agreePetition(@RequestBody AgreementRequest agreementRequest,
+                                              @PathVariable Long petitionId,
+                                              @LoginUser SimpleUser simpleUser) {
+        petitionService.agree(agreementRequest, petitionId, simpleUser.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -116,7 +116,7 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrievePetitionsByUserId(simpleUser.getId(), pageable));
     }
 
-    @AdminPermissionRequired
+    @ManagerPermissionRequired
     @GetMapping("/petitions/{petitionId}/revisions")
     public ResponseEntity<Page<PetitionRevisionResponse>> retrieveRevisionsOfPetition(@PathVariable Long petitionId,
                                                                                       @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -51,7 +51,7 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
-    //@AdminPermissionRequired
+    @AdminPermissionRequired
     @GetMapping("/petitions/all")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveAllPetitions(@RequestParam(defaultValue = "0") Long categoryId,
                                                                               @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionController.java
@@ -35,7 +35,7 @@ public class PetitionController {
 
     @GetMapping("/petitions/ongoing")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveOngoingPetitions(@RequestParam(defaultValue = "0") Long categoryId,
-                                                                                   @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                                                  @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         if (categoryId.equals(0L)) {
             return ResponseEntity.ok().body(petitionService.retrieveOngoingPetition(pageable));
         }
@@ -128,8 +128,6 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveReleasedPetitionCount());
     }
 
-
-
     @ManagerPermissionRequired
     @PutMapping("/petitions/{petitionId}")
     public ResponseEntity<Void> updatePetition(@PathVariable Long petitionId,
@@ -160,11 +158,6 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveAgreements(petitionId, pageable));
     }
 
-    @GetMapping("/petitions/{petitionId}/agreements/number")
-    public ResponseEntity<Integer> retrieveNumberOfAgreement(@PathVariable Long petitionId) {
-        return ResponseEntity.ok().body(petitionService.retrieveNumberOfAgreements(petitionId));
-    }
-
     @LoginRequired
     @GetMapping("/petitions/{petitionId}/agreements/me")
     public ResponseEntity<Boolean> retrieveStateOfAgreement(@PathVariable Long petitionId,
@@ -175,11 +168,6 @@ public class PetitionController {
     @GetMapping("/petitions/temp/{tempUrl}")
     public ResponseEntity<PetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
         return ResponseEntity.ok().body(petitionService.retrievePetitionByTempUrl(tempUrl));
-    }
-
-    @GetMapping("/petitions/best")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveBestPetition(Pageable pageable) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionsOrderByAgreeCount(pageable));
     }
 
     @ManagerPermissionRequired

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
@@ -1,11 +1,13 @@
 package com.gistpetition.api.petition.presentation;
 
-import com.gistpetition.api.config.annotation.AdminPermissionRequired;
 import com.gistpetition.api.config.annotation.LoginRequired;
 import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
 import com.gistpetition.api.petition.application.PetitionService;
-import com.gistpetition.api.petition.dto.*;
+import com.gistpetition.api.petition.dto.AgreementResponse;
+import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
+import com.gistpetition.api.petition.dto.PetitionResponse;
+import com.gistpetition.api.petition.dto.PetitionRevisionResponse;
 import com.gistpetition.api.user.domain.SimpleUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,25 +15,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
-public class PetitionController {
+public class PetitionQueryController {
     private final PetitionService petitionService;
-
-    @LoginRequired
-    @PostMapping("/petitions")
-    public ResponseEntity<Void> createPetition(@Validated @RequestBody PetitionRequest petitionRequest,
-                                               @LoginUser SimpleUser simpleUser) {
-        Long createdPetitionId = petitionService.createPetition(petitionRequest, simpleUser.getId());
-        String tempUrl = petitionService.retrieveTempUrlOf(createdPetitionId);
-        return ResponseEntity.created(URI.create("/petitions/temp/" + tempUrl)).build();
-    }
 
     @GetMapping("/petitions/ongoing")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveOngoingPetitions(@RequestParam(defaultValue = "0") Long categoryId,
@@ -51,40 +41,6 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveReleasedAndExpiredPetitionByCategoryId(categoryId, pageable));
     }
 
-    @AdminPermissionRequired
-    @GetMapping("/petitions/all")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveAllPetitions(@RequestParam(defaultValue = "0") Long categoryId,
-                                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        if (categoryId.equals(0L)) {
-            return ResponseEntity.ok().body(petitionService.retrievePetition(pageable));
-        }
-        return ResponseEntity.ok().body(petitionService.retrievePetitionByCategoryId(categoryId, pageable));
-    }
-
-    @ManagerPermissionRequired
-    @GetMapping("/petitions/waitingForRelease")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForCheck(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionsWaitingForRelease(pageable));
-    }
-
-    @ManagerPermissionRequired
-    @GetMapping("/petitions/waitingForAnswer")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForAnswer(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionsWaitingForAnswer(pageable));
-    }
-
-    @ManagerPermissionRequired
-    @GetMapping("/petitions/waitingForRelease/count")
-    public ResponseEntity<Long> retrievePetitionsWaitingForCheckCount() {
-        return ResponseEntity.ok().body(petitionService.retrieveWaitingForReleasePetitionCount());
-    }
-
-    @ManagerPermissionRequired
-    @GetMapping("/petitions/waitingForAnswer/count")
-    public ResponseEntity<Long> retrievePetitionsWaitingForAnswerCount() {
-        return ResponseEntity.ok().body(petitionService.retrieveWaitingForAnswerPetitionCount());
-    }
-
     @GetMapping("/petitions/answered")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveAnsweredPetitions(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok().body(petitionService.retrieveAnsweredPetition(pageable));
@@ -95,18 +51,43 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveAnsweredPetitionCount());
     }
 
-    @GetMapping("/petitions/search")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsByKeyword(@RequestParam(defaultValue = "") String keyword,
-                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        if (keyword.equals("")) {
-            return ResponseEntity.ok().body(petitionService.retrievePetition(pageable));
-        }
-        return ResponseEntity.ok().body(petitionService.retrievePetitionByKeyword(keyword, pageable));
+    @ManagerPermissionRequired
+    @GetMapping("/petitions/waitingForRelease")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForCheck(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(petitionService.retrievePetitionsWaitingForRelease(pageable));
+    }
+
+    @ManagerPermissionRequired
+    @GetMapping("/petitions/waitingForRelease/count")
+    public ResponseEntity<Long> retrievePetitionsWaitingForCheckCount() {
+        return ResponseEntity.ok().body(petitionService.retrieveWaitingForReleasePetitionCount());
+    }
+
+    @ManagerPermissionRequired
+    @GetMapping("/petitions/waitingForAnswer")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForAnswer(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(petitionService.retrievePetitionsWaitingForAnswer(pageable));
+    }
+
+    @ManagerPermissionRequired
+    @GetMapping("/petitions/waitingForAnswer/count")
+    public ResponseEntity<Long> retrievePetitionsWaitingForAnswerCount() {
+        return ResponseEntity.ok().body(petitionService.retrieveWaitingForAnswerPetitionCount());
+    }
+
+    @GetMapping("/petitions/count")
+    public ResponseEntity<Long> retrieveReleasedPetitionCount() {
+        return ResponseEntity.ok().body(petitionService.retrieveReleasedPetitionCount());
     }
 
     @GetMapping("/petitions/{petitionId}")
     public ResponseEntity<PetitionResponse> retrieveReleasedPetition(@PathVariable Long petitionId) {
         return ResponseEntity.ok().body(petitionService.retrieveReleasedPetitionById(petitionId));
+    }
+
+    @GetMapping("/petitions/temp/{tempUrl}")
+    public ResponseEntity<PetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
+        return ResponseEntity.ok().body(petitionService.retrievePetitionByTempUrl(tempUrl));
     }
 
     @LoginRequired
@@ -123,33 +104,13 @@ public class PetitionController {
         return ResponseEntity.ok().body(petitionService.retrieveRevisionsOfPetition(petitionId, pageable));
     }
 
-    @GetMapping("/petitions/count")
-    public ResponseEntity<Long> retrieveReleasedPetitionCount() {
-        return ResponseEntity.ok().body(petitionService.retrieveReleasedPetitionCount());
-    }
-
-    @ManagerPermissionRequired
-    @PutMapping("/petitions/{petitionId}")
-    public ResponseEntity<Void> updatePetition(@PathVariable Long petitionId,
-                                               @Validated @RequestBody PetitionRequest changeRequest) {
-        petitionService.updatePetition(petitionId, changeRequest);
-        return ResponseEntity.noContent().build();
-    }
-
-    @ManagerPermissionRequired
-    @DeleteMapping("/petitions/{petitionId}")
-    public ResponseEntity<Void> deletePetition(@PathVariable Long petitionId) {
-        petitionService.deletePetition(petitionId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @LoginRequired
-    @PostMapping("/petitions/{petitionId}/agreements")
-    public ResponseEntity<Void> agreePetition(@RequestBody AgreementRequest agreementRequest,
-                                              @PathVariable Long petitionId,
-                                              @LoginUser SimpleUser simpleUser) {
-        petitionService.agree(agreementRequest, petitionId, simpleUser.getId());
-        return ResponseEntity.ok().build();
+    @GetMapping("/petitions/search")
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsByKeyword(@RequestParam(defaultValue = "") String keyword,
+                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        if (keyword.equals("")) {
+            return ResponseEntity.ok().body(petitionService.retrievePetition(pageable));
+        }
+        return ResponseEntity.ok().body(petitionService.retrievePetitionByKeyword(keyword, pageable));
     }
 
     @GetMapping("/petitions/{petitionId}/agreements")
@@ -163,17 +124,5 @@ public class PetitionController {
     public ResponseEntity<Boolean> retrieveStateOfAgreement(@PathVariable Long petitionId,
                                                             @LoginUser SimpleUser simpleUser) {
         return ResponseEntity.ok().body(petitionService.retrieveStateOfAgreement(petitionId, simpleUser.getId()));
-    }
-
-    @GetMapping("/petitions/temp/{tempUrl}")
-    public ResponseEntity<PetitionResponse> retrieveTempPetition(@PathVariable String tempUrl) {
-        return ResponseEntity.ok().body(petitionService.retrievePetitionByTempUrl(tempUrl));
-    }
-
-    @ManagerPermissionRequired
-    @PostMapping("/petitions/{petitionId}/release")
-    public ResponseEntity<Void> releasePetition(@PathVariable Long petitionId) {
-        petitionService.releasePetition(petitionId);
-        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
api가 많아 짐에 따라 Query와 Command의 Controller 분리를 진행했습니다. -> 추후에 Service레이어에서도 분리를 진행할 수 있을 거라 생각됩니다.

수정 이력을 매니저 또한 볼 수 있도록, 권한을 수정했습니다. (admin -> manager)

추가적으로 사용되지 않는 api 삭제 또한 진행했습니다.