### PR TITLE
feat: flyway 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
     runtimeOnly 'com.h2database:h2'
+    implementation 'org.flywaydb:flyway-core'
     runtimeOnly 'mysql:mysql-connector-java'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ server.servlet.session.cookie:
   path: /
   secure: true
   sameSite: None
+
 ---
 spring:
   config:
@@ -31,9 +32,16 @@ spring:
     activate:
       on-profile: dev
     import: ./privates/application-dev-db.yml, ./privates/application-dev-mail.yml
+
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
+    generate-ddl: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
 swagger:
   host: dev-api.gist-petition.com
   protocol: https

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    generate-ddl: false
 
   flyway:
     enabled: true

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -5,7 +5,7 @@ create table if not exists answer
     updated_at datetime(6) null,
     content longtext null,
     petition_id bigint null,
-    constraint UK_8o2ycrbsqgsqe35984pfkhhlg
+    constraint uk_answer_petition_id
         unique (petition_id)
 );
 
@@ -32,7 +32,7 @@ create table if not exists petition
     temp_url varchar(255) null,
     title varchar(255) null,
     user_id bigint null,
-    constraint UK_lbp7lx6brl567xxtwq9trc8t7
+    constraint uk_petition_temp_url
         unique (temp_url)
 );
 
@@ -43,9 +43,9 @@ create table if not exists agreement
     description longtext null,
     user_id bigint null,
     petition_id bigint null,
-    constraint UK6b2jp4145qyhk2hsvxoes773p
+    constraint uk_agreement_user_id_petition_id
         unique (user_id, petition_id),
-    constraint FK38mj0s6cdysv5aescp81w989v
+    constraint fk_agreement_petition_petition_id
         foreign key (petition_id) references petition (id)
 );
 
@@ -64,7 +64,7 @@ create table if not exists answer_aud
     content longtext null,
     petition_id bigint null,
     primary key (id, rev),
-    constraint FK93g4u12fhre47t3kpaag6r60c
+    constraint fk_answer_aud_revinfo_rev
         foreign key (rev) references revinfo (rev)
 );
 
@@ -82,7 +82,7 @@ create table if not exists petition_aud
     title varchar(255) null,
     user_id bigint null,
     primary key (id, rev),
-    constraint FKpubpwgg3epkfagt9psdcxdeeh
+    constraint fk_petition_aud_revinfo_rev
         foreign key (rev) references revinfo (rev)
 );
 
@@ -103,6 +103,6 @@ create table if not exists user
     password varchar(255) null,
     user_role varchar(255) null,
     username varchar(255) null,
-    constraint UK_sb8bbouer5wak8vyiiy4pf2bx
+    constraint uk_user_username
         unique (username)
 );

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,108 @@
+create table if not exists answer
+(
+    id bigint auto_increment primary key,
+    created_at datetime(6) null,
+    updated_at datetime(6) null,
+    content longtext null,
+    petition_id bigint null,
+    constraint UK_8o2ycrbsqgsqe35984pfkhhlg
+        unique (petition_id)
+);
+
+create table if not exists password_verification_info
+(
+    id bigint auto_increment primary key,
+    confirmed_at datetime(6) null,
+    created_at datetime(6) null,
+    username varchar(255) null,
+    verification_code varchar(255) null
+);
+
+create table if not exists petition
+(
+    id bigint auto_increment primary key,
+    created_at datetime(6) null,
+    updated_at datetime(6) null,
+    agree_count int null,
+    answered bit null,
+    category varchar(255) null,
+    description longtext null,
+    expired_at datetime(6) null,
+    released bit null,
+    temp_url varchar(255) null,
+    title varchar(255) null,
+    user_id bigint null,
+    constraint UK_lbp7lx6brl567xxtwq9trc8t7
+        unique (temp_url)
+);
+
+create table if not exists agreement
+(
+    id bigint auto_increment primary key,
+    created_at datetime(6) null,
+    description longtext null,
+    user_id bigint null,
+    petition_id bigint null,
+    constraint UK6b2jp4145qyhk2hsvxoes773p
+        unique (user_id, petition_id),
+    constraint FK38mj0s6cdysv5aescp81w989v
+        foreign key (petition_id) references petition (id)
+);
+
+create table if not exists revinfo
+(
+    rev bigint auto_increment primary key,
+    revtstmp bigint null,
+    user_id bigint null
+);
+
+create table if not exists answer_aud
+(
+    id bigint not null,
+    rev bigint not null,
+    revtype tinyint null,
+    content longtext null,
+    petition_id bigint null,
+    primary key (id, rev),
+    constraint FK93g4u12fhre47t3kpaag6r60c
+        foreign key (rev) references revinfo (rev)
+);
+
+create table if not exists petition_aud
+(
+    id bigint not null,
+    rev bigint not null,
+    revtype tinyint null,
+    answered bit null,
+    category varchar(255) null,
+    description longtext null,
+    expired_at datetime(6) null,
+    released bit null,
+    temp_url varchar(255) null,
+    title varchar(255) null,
+    user_id bigint null,
+    primary key (id, rev),
+    constraint FKpubpwgg3epkfagt9psdcxdeeh
+        foreign key (rev) references revinfo (rev)
+);
+
+create table if not exists sign_up_verification_info
+(
+    id bigint auto_increment primary key,
+    confirmed_at datetime(6) null,
+    created_at datetime(6) null,
+    username varchar(255) null,
+    verification_code varchar(255) null
+);
+
+create table if not exists user
+(
+    id bigint auto_increment primary key,
+    created_at datetime(6) null,
+    updated_at datetime(6) null,
+    password varchar(255) null,
+    user_role varchar(255) null,
+    username varchar(255) null,
+    constraint UK_sb8bbouer5wak8vyiiy4pf2bx
+        unique (username)
+);


### PR DESCRIPTION
close #247 

데이터베이스의 변경 이력을 남기고, DB간 마이그레이션을 용이하게 하기 위해 flyway 를 도입하였습니다.
---
뭔지 궁금하신 분은 다음 영상을 참고해주세요.
https://www.ecsimsw.com/entry/Flyway%EB%A1%9C-DB-Migration

안정적이고 신뢰성 있는 운영환경에서의 DB 관리를 위해 도입이 필요하다고 판단됩니다.
다같이 사용법을 공유하는 시간이 필요할 듯 합니다.

@koseyeon 당신도 영상 보고오세요