### PR TITLE
refactor: Agreement `@OneToMany` 관계 Cascade설정 적용으로 단순화

### DIFF
--- a/src/main/java/com/gistpetition/api/config/aop/DataIntegrityAspect.java
+++ b/src/main/java/com/gistpetition/api/config/aop/DataIntegrityAspect.java
@@ -4,10 +4,12 @@ import com.gistpetition.api.config.annotation.DataIntegrityHandler;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Aspect
+@Order(1)
 @Component
 public class DataIntegrityAspect {
     @Around("@annotation(dataIntegrityHandler)")

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
@@ -28,7 +28,6 @@ public class PetitionCommandService {
 
     private static final int TEMP_URL_LENGTH = 6;
     private final PetitionRepository petitionRepository;
-    private final AgreementRepository agreementRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final UrlGenerator urlGenerator;

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
@@ -4,7 +4,10 @@ import com.gistpetition.api.config.annotation.DataIntegrityHandler;
 import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.exception.petition.NoSuchPetitionException;
 import com.gistpetition.api.exception.user.NoSuchUserException;
-import com.gistpetition.api.petition.domain.*;
+import com.gistpetition.api.petition.domain.AgreementRepository;
+import com.gistpetition.api.petition.domain.Category;
+import com.gistpetition.api.petition.domain.Petition;
+import com.gistpetition.api.petition.domain.PetitionRepository;
 import com.gistpetition.api.petition.dto.AgreementRequest;
 import com.gistpetition.api.petition.dto.PetitionRequest;
 import com.gistpetition.api.user.domain.User;
@@ -66,9 +69,7 @@ public class PetitionCommandService {
     public void agree(AgreementRequest request, Long petitionId, Long userId) {
         Petition petition = findPetitionById(petitionId);
         User user = findUserById(userId);
-        Agreement agreement = new Agreement(request.getDescription(), user.getId());
-        agreement.setPetition(petition, Instant.now());
-        agreementRepository.save(agreement);
+        petition.agree(user.getId(), request.getDescription(), Instant.now());
     }
 
     @Transactional

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -37,11 +37,6 @@ public class Agreement extends UnmodifiableEntity {
         return this.userId.equals(userId);
     }
 
-    public void setPetition(Petition petition, Instant at) {
-        this.petition = petition;
-        petition.addAgreement(this, at);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreement.java
@@ -16,9 +16,8 @@ public class Agreement extends UnmodifiableEntity {
     private String description;
     @Column(name = "user_id")
     private Long userId;
-
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "petition_id")
+    @JoinColumn(name = "petition_id", referencedColumnName = "id")
     private Petition petition;
 
     protected Agreement() {
@@ -28,7 +27,7 @@ public class Agreement extends UnmodifiableEntity {
         this(description, userId, null);
     }
 
-    private Agreement(String description, Long userId, Petition petition) {
+    public Agreement(String description, Long userId, Petition petition) {
         this.description = description;
         this.userId = userId;
         this.petition = petition;

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreements.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreements.java
@@ -3,6 +3,7 @@ package com.gistpetition.api.petition.domain;
 import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import org.hibernate.annotations.BatchSize;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
@@ -13,11 +14,10 @@ import java.util.List;
 public class Agreements {
 
     @BatchSize(size = 10)
-    @OneToMany(mappedBy = "petition", orphanRemoval = true)
+    @OneToMany(mappedBy = "petition", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private final List<Agreement> agreements = new ArrayList<>();
 
     protected Agreements() {
-
     }
 
     public void add(Agreement agreement) {

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -1,7 +1,10 @@
 package com.gistpetition.api.petition.domain;
 
 import com.gistpetition.api.common.persistence.BaseEntity;
-import com.gistpetition.api.exception.petition.*;
+import com.gistpetition.api.exception.petition.AlreadyReleasedPetitionException;
+import com.gistpetition.api.exception.petition.ExpiredPetitionException;
+import com.gistpetition.api.exception.petition.NotEnoughAgreementException;
+import com.gistpetition.api.exception.petition.NotReleasedPetitionException;
 import com.gistpetition.api.user.domain.User;
 import lombok.Getter;
 import org.hibernate.envers.Audited;
@@ -35,8 +38,6 @@ public class Petition extends BaseEntity {
     @Embedded
     private final Agreements agreements = new Agreements();
 
-
-
     protected Petition() {
     }
 
@@ -54,6 +55,14 @@ public class Petition extends BaseEntity {
             throw new ExpiredPetitionException();
         }
         this.agreements.add(newAgreement);
+        this.agreeCount += 1;
+    }
+
+    public void agree(Long userId, String description, Instant at) {
+        if (isExpiredAt(at)) {
+            throw new ExpiredPetitionException();
+        }
+        this.agreements.add(new Agreement(description, userId, this));
         this.agreeCount += 1;
     }
 

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -35,17 +35,16 @@ class PetitionTest {
 
     @Test
     void agree() {
-        Agreement agreement = new Agreement(AGREEMENT_DESCRIPTION, 1L);
-        petition.addAgreement(agreement, PETITION_ONGOING_AT);
+        petition.agree(1L, AGREEMENT_DESCRIPTION, PETITION_ONGOING_AT);
 
         assertThat(petition.getAgreeCount()).isEqualTo(1);
     }
 
     @Test
     void agreeByMultipleUser() {
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L), PETITION_ONGOING_AT);
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 2L), PETITION_ONGOING_AT);
-        petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 3L), PETITION_ONGOING_AT);
+        petition.agree(1L, AGREEMENT_DESCRIPTION, PETITION_ONGOING_AT);
+        petition.agree(2L, AGREEMENT_DESCRIPTION, PETITION_ONGOING_AT);
+        petition.agree(3L, AGREEMENT_DESCRIPTION, PETITION_ONGOING_AT);
 
         assertThat(petition.getAgreeCount()).isEqualTo(3);
     }
@@ -53,13 +52,13 @@ class PetitionTest {
     @Test
     void agreeExpiredPetition() {
         assertThatThrownBy(() ->
-                petition.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, 1L), PETITION_EXPIRED_AT.plusSeconds(1))
+                petition.agree(1L, AGREEMENT_DESCRIPTION, PETITION_EXPIRED_AT.plusSeconds(1))
         ).isInstanceOf(ExpiredPetitionException.class);
     }
 
     @Test
     void release() {
-        agreePetition(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
+        agreePetitionByMultipleUsers(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
 
         petition.release(PETITION_ONGOING_AT);
 
@@ -68,7 +67,7 @@ class PetitionTest {
 
     @Test
     void releaseAlreadyReleased() {
-        agreePetition(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
+        agreePetitionByMultipleUsers(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
         petition.release(PETITION_ONGOING_AT);
 
         assertThatThrownBy(
@@ -84,7 +83,7 @@ class PetitionTest {
 
     @Test
     void releaseExpiredPetition() {
-        agreePetition(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
+        agreePetitionByMultipleUsers(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
 
         petition.release(PETITION_ONGOING_AT);
 
@@ -95,7 +94,7 @@ class PetitionTest {
 
     @Test
     void cancelRelease() {
-        agreePetition(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
+        agreePetitionByMultipleUsers(petition, REQUIRED_AGREEMENT_FOR_RELEASE);
         petition.release(PETITION_ONGOING_AT);
 
         petition.cancelRelease();
@@ -110,8 +109,8 @@ class PetitionTest {
         ).isInstanceOf(NotReleasedPetitionException.class);
     }
 
-    private void agreePetition(Petition target, int numOfUsers) {
-        LongStream.range(0, numOfUsers)
-                .forEach(userId -> target.addAgreement(new Agreement(AGREEMENT_DESCRIPTION, userId), PETITION_ONGOING_AT));
+    private void agreePetitionByMultipleUsers(Petition target, int numberOfUsers) {
+        LongStream.range(0, numberOfUsers)
+                .forEach(userId -> target.agree(userId, AGREEMENT_DESCRIPTION, PETITION_ONGOING_AT));
     }
 }


### PR DESCRIPTION
전에 OneToMany 단방향으로 구성했을 때 Cascade를 이용했었는데, 이 부분을 양방향으로 변경하게 되었을 때 다르게 처리해야만 하는 줄 알았고, Agreement를 db에 저장하는 방식으로 진행을 했다. 아래 참고자료를 보다보니 확인했을 때 가능함을 확인했고, 보다 객체 지향적인 코드를 짤 수 있게 되었습니다.

Agreements로 분리가되서 더 쉽게 수정을 진행할 수 있었습니다! 👍 

https://cheese10yun.github.io/spring-jpa-best-05/
https://cheese10yun.github.io/spring-jpa-best-09/
