### PR TITLE
fix: categoryId = 0 일 때 전체 조회하도록 수정

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/domain/Category.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Category.java
@@ -18,7 +18,6 @@ public enum Category {
     COMMUNICATION(8L, "권익소통"),
     ETC(9L, "기타");
 
-
     private final Long id;
     private final String name;
 
@@ -43,6 +42,9 @@ public enum Category {
     }
 
     public static Optional<Category> of(Optional<Long> categoryId) {
+        if (categoryId.isPresent() && categoryId.get().equals(0L)) {
+            return Optional.empty();
+        }
         return categoryId.map(Category::of);
     }
 


### PR DESCRIPTION
지금의 Optional의 사용이 좋은 구현인지는 모르겠으나, 가장 쉽게 수정할 수 있어 유지했습니다.