### PR TITLE
fix: AgreeCount로 정렬 조회시 발생하는 문제 해결 및 테스트 추가

### DIFF
--- a/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
@@ -14,6 +14,7 @@ import com.querydsl.jpa.JPQLQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
@@ -67,7 +68,14 @@ public class PetitionQueryDslRepository {
         PathBuilder<Petition> entityPath = new PathBuilder<>(Petition.class, "petition");
         return pageable.getSort()
                 .stream()
-                .map(order -> new OrderSpecifier(Order.valueOf(order.getDirection().name()), entityPath.get(order.getProperty())))
+                .map(order -> getOrderSpecifier(entityPath, order))
                 .toArray(OrderSpecifier[]::new);
+    }
+
+    private OrderSpecifier getOrderSpecifier(PathBuilder<Petition> entityPath, Sort.Order order) {
+        if ("agreeCount".equals(order.getProperty())) {
+            return new OrderSpecifier(Order.valueOf(order.getDirection().name()), agreeCount.count);
+        }
+        return new OrderSpecifier(Order.valueOf(order.getDirection().name()), entityPath.get(order.getProperty()));
     }
 }


### PR DESCRIPTION
우선은 급한 불을 끄는 느낌으로 진행했으나, 현재의 sorting방식은 petition의 모든 column에 대해 다 열어준 상황이고, 이 sorting 방식에 대해서도 열어줄 것을 정하고 별도로 정의해야 한다고 생각합니다.

PetitionQueryCondition과 비슷하게 PetitionQuerySorting 과 관련된 enum을 하나 정의해서 관리할 수 있을 것 같아요