### PR TITLE
feat: 처리되지 않은 ExceptionHanlder에 대한 추가 및 정리

### DIFF
--- a/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
+++ b/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
@@ -3,6 +3,7 @@ package com.gistpetition.api.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.TypeMismatchException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -48,6 +49,12 @@ public class ControllerAdvice {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handle(HttpRequestMethodNotSupportedException ex) {
         LOGGER.info(String.format("HttpRequestMethodNotSupportedException: %s", ex.getMessage()));
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handle(OptimisticLockingFailureException ex) {
+        LOGGER.info(String.format("OptimisticLockingFailureException: %s", ex.getMessage()));
         return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
     }
 

--- a/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
+++ b/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
@@ -17,7 +17,6 @@ public class ControllerAdvice {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> handle(ApplicationException ex) {
-        LOGGER.info(String.format("ApplicationException: %s", ex.getMessage()));
         return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getMessage()));
     }
 

--- a/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
+++ b/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 public class ControllerAdvice {
@@ -28,6 +29,12 @@ public class ControllerAdvice {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         LOGGER.info(String.format("MethodArgumentNotValidException: %s", message));
         return ResponseEntity.badRequest().body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handle(NoHandlerFoundException ex) {
+        LOGGER.info(String.format("NoHandlerFoundException: %s", ex.getMessage()));
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
+++ b/src/main/java/com/gistpetition/api/exception/ControllerAdvice.java
@@ -2,7 +2,9 @@ package com.gistpetition.api.exception;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -34,6 +36,18 @@ public class ControllerAdvice {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handle(NoHandlerFoundException ex) {
         LOGGER.info(String.format("NoHandlerFoundException: %s", ex.getMessage()));
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handle(TypeMismatchException ex) {
+        LOGGER.info(String.format("TypeMismatchException: %s", ex.getMessage()));
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handle(HttpRequestMethodNotSupportedException ex) {
+        LOGGER.info(String.format("HttpRequestMethodNotSupportedException: %s", ex.getMessage()));
         return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   profiles:
     active: local
+  web:
+    resources:
+      add-mappings: false
+  mvc:
+    throw-exception-if-no-handler-found: true
+
 
 server.servlet.session.cookie:
   http-only: true

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -456,7 +457,7 @@ class PetitionServiceTest extends IntegrationTest {
             service.execute(() -> {
                 try {
                     petitionCommandService.answerPetition(petitionId, ANSWER_REQUEST);
-                } catch (Exception ex) {
+                } catch (OptimisticLockingFailureException ex) {
                     errorCount.incrementAndGet();
                 } finally {
                     latch.countDown();


### PR DESCRIPTION
Cloudwatch  알람 기능이 추가되면서, 예상가능하고 의도된 에러 들에 대한 Exception 핸들러를 추가했습니다.

또한 기본적으로 경로가 존재하지 않을 때, 모두 resource를 검색하는 게 Spring의 기본 구조인데, 이 옵션을 끄고 별도의 설정을 진행해줬습니다.

이슈 내용 확인해주시고, 필요하다면 줌으로 코드 설명 진행하겠습니다.

close #314 
close #316 