### PR TITLE
[v1.1.9] 지스트 청원 배포 (#363)

### DIFF
--- a/src/main/java/com/gistpetition/api/DataLoader.java
+++ b/src/main/java/com/gistpetition/api/DataLoader.java
@@ -111,6 +111,10 @@ public class DataLoader {
         }
 
         IntStream.range(0, 5).forEach(i -> saveExpiredPetition(normal, users));
+
+        Long oneLeftPetition = savePetition("동의 한개 남은 청원", normal);
+        agreePetitionOneLessThanRequiredForAnswer(oneLeftPetition, users);
+        petitionCommandService.releasePetition(oneLeftPetition);
     }
 
     private User savedUser(int i) {
@@ -119,6 +123,14 @@ public class DataLoader {
 
     private void randomlyAgreePetitionOverRequired(Long petitionId, List<User> alphabetUsers) {
         int agreeCount = RANDOM.nextInt(alphabetUsers.size() - REQUIRED_AGREEMENT_FOR_ANSWER) + REQUIRED_AGREEMENT_FOR_ANSWER;
+        for (int j = 0; j < agreeCount; j++) {
+            User user = alphabetUsers.get(j);
+            petitionCommandService.agree(AGREEMENT_REQUEST, petitionId, user.getId());
+        }
+    }
+
+    private void agreePetitionOneLessThanRequiredForAnswer(Long petitionId, List<User> alphabetUsers) {
+        int agreeCount = REQUIRED_AGREEMENT_FOR_ANSWER - 1;
         for (int j = 0; j < agreeCount; j++) {
             User user = alphabetUsers.get(j);
             petitionCommandService.agree(AGREEMENT_REQUEST, petitionId, user.getId());

--- a/src/main/java/com/gistpetition/api/petition/domain/Agreements.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Agreements.java
@@ -43,4 +43,8 @@ public class Agreements {
     public int size() {
         return agreements.size();
     }
+
+    public boolean hasSize(int size) {
+        return agreements.size() == size;
+    }
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -27,7 +27,10 @@ public class Petition extends BaseEntity {
     private Description description;
     @Enumerated(EnumType.STRING)
     private Category category;
+    @NotAudited
     private Boolean released = false;
+    @NotAudited
+    private Instant waitingForAnswerAt;
     private Instant expiredAt;
     private Long userId;
     @Column(unique = true)
@@ -66,6 +69,10 @@ public class Petition extends BaseEntity {
             throw new ExpiredPetitionException();
         }
         this.agreements.add(new Agreement(description, userId, this));
+
+        if (agreements.hasSize(REQUIRED_AGREEMENT_FOR_ANSWER)) {
+            this.waitingForAnswerAt = at;
+        }
     }
 
     public boolean isAgreedBy(User user) {

--- a/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
@@ -65,7 +65,7 @@ public class PetitionQueryDslRepository {
     }
 
     private QPetitionPreviewResponse buildPetitionPreviewResponse() {
-        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.createdAt, petition.expiredAt, agreeCount.count, petition.tempUrl, petition.released, petition.rejection.isNotNull(), petition.answer.isNotNull());
+        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.createdAt, petition.expiredAt, petition.waitingForAnswerAt, agreeCount.count, petition.tempUrl, petition.released, petition.rejection.isNotNull(), petition.answer.isNotNull());
     }
 
     private BooleanExpression categoryEq(Category category) {

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -15,6 +15,7 @@ public class PetitionPreviewResponse {
     private String categoryName;
     private Integer agreeCount;
     private Long createdAt;
+    private Long waitingForAnswerAt;
     private String tempUrl;
     private Boolean released;
     private Boolean rejected;
@@ -22,11 +23,12 @@ public class PetitionPreviewResponse {
     private Boolean expired;
 
     @QueryProjection
-    public PetitionPreviewResponse(Long id, String title, Category category, Instant createdAt, Instant expiredAt, Integer agreeCount, String tempUrl, Boolean released, Boolean rejected, Boolean answered) {
+    public PetitionPreviewResponse(Long id, String title, Category category, Instant createdAt, Instant expiredAt, Instant waitingForAnswerAt, Integer agreeCount, String tempUrl, Boolean released, Boolean rejected, Boolean answered) {
         this.id = id;
         this.title = title;
         this.categoryName = category.getName();
         this.createdAt = createdAt.toEpochMilli();
+        this.waitingForAnswerAt = waitingForAnswerAt != null ? waitingForAnswerAt.toEpochMilli() : null;
         this.agreeCount = agreeCount;
         this.tempUrl = tempUrl;
         this.released = released;

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
@@ -20,6 +20,7 @@ public class PetitionResponse {
     private Integer agreeCount;
     private Long createdAt;
     private Long updatedAt;
+    private Long waitingForAnswerAt;
     private String tempUrl;
     private Boolean released;
     private Boolean rejected;
@@ -29,6 +30,7 @@ public class PetitionResponse {
     private AnswerResponse answer;
 
     public static PetitionResponse of(Petition petition) {
+        Instant waitingForAnswerAt = petition.getWaitingForAnswerAt();
         Rejection rejection = petition.getRejection();
         Answer answer = petition.getAnswer();
         return new PetitionResponse(
@@ -39,6 +41,7 @@ public class PetitionResponse {
                 petition.getAgreeCount(),
                 petition.getCreatedAt().toEpochMilli(),
                 petition.getUpdatedAt().toEpochMilli(),
+                waitingForAnswerAt != null ? waitingForAnswerAt.toEpochMilli() : null,
                 petition.getTempUrl(),
                 petition.isReleased(),
                 petition.isRejected(),

--- a/src/main/resources/db/migration/V1_11__add_petition_waiting_for_answer_at.sql
+++ b/src/main/resources/db/migration/V1_11__add_petition_waiting_for_answer_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE petition
+    ADD waiting_for_answer_at datetime NULL;

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -70,6 +70,17 @@ class PetitionTest {
         petition.agree(3L, AGREEMENT_DESCRIPTION, PETITION_NOT_EXPIRED_AT);
 
         assertThat(petition.getAgreeCount()).isEqualTo(3);
+        assertThat(petition.getWaitingForAnswerAt()).isNull();
+    }
+
+    @Test
+    void agreeByWaitingForAnswerTimes() {
+        for (long i = 0; i < REQUIRED_AGREEMENT_FOR_ANSWER; i++) {
+            petition.agree(i, AGREEMENT_DESCRIPTION, PETITION_NOT_EXPIRED_AT);
+        }
+
+        assertThat(petition.getAgreeCount()).isEqualTo(REQUIRED_AGREEMENT_FOR_ANSWER);
+        assertThat(petition.getWaitingForAnswerAt()).isEqualTo(PETITION_NOT_EXPIRED_AT);
     }
 
     @Test


### PR DESCRIPTION
* Create README.md

* [add] user domain

* add user post and password encoder

* aws rds connect

* [add] post jpa and connect sql

* [add] comment

* [refactor] refactor post architecture

* [add] gitignore

* [test] test api

* [add] cors config

* [fix] fix user domain

* [fix] api loop error by using @JsonIgnore

* [add] docker settings for severless

* create getPostbyuserid

* modify comment API

* fix comment bug and create fuction : get posts by category

* [fix] comment property change LocalDateTime -> String

* [add] sql and add comment

* [fix] remove transaction

* [fix] modify Dockerfile and gradlew for deployment (windows->unix)

* [add] create ANSWER API

* [add] create ANSWER API

* [fix] answerAPI controller fixed

* [remove] remove dockerfile

* [rm] remove dockerfile

* [add] .gcloudignore

* [fix] db connect?

* [fix] db connection

* [add] smtp email authentication

* feature: 다양한 기능 구현(민감 정보 삭제를 위해 커밋 병합)

* [add] email resend

(cherry picked from commit 884be357248f685e7bb5bb68fc60363164975298)

* [feat] 좋아요 기능 구현

(cherry picked from commit 2f0ea14876e77f3289fe2e65a4d4d90d1a1a5f93)

* [fix] jwt issue

(cherry picked from commit 5364a8d9b41a64bd922660a596bdd03017de5e03)

* [refactor] refactor post

(cherry picked from commit e4641b2bebbe2aae811f507379f4ff1617584f04)

* [refactor] builder pattern

(cherry picked from commit 0096bb5edef99632083b7a1e9852b3aeccef7fe5)

* [refactor] change if statement

(cherry picked from commit f34a33f15c714f39226dc3fe0f0b5955efa77d71)

* [add] cors

(cherry picked from commit 0dace1515e0c94dd57e3df6bc2d03053dd2a3d4f)

* [modify] SecurityConfig 에서 CORS 설정

(cherry picked from commit 4653d248116ac4b665406315c2b998c996af67fb)

* [fix] allow all cors temporary

(cherry picked from commit 2de81b6e53025e51d4c09edb82a1393de7c090ec)

* [fix] mail sender

(cherry picked from commit cadc083a0224397c598afe80e5d816dd4c9031a6)

* [add] change email name

(cherry picked from commit f9b0e0c344da8f1b1a2bbb644e1273c5bdc84637)

* [remove] legacy package

(cherry picked from commit d263fb43aa06f7fbcf4dc9757de5fc6f5ce6b682)

* [add] error case

(cherry picked from commit 7c585386204d13207b28d6354c538df669168caa)

* [fix] solve n+1 problem by using distinct fetch join

(cherry picked from commit 528110ffab65d3e70f2fc2fa309d639e273f1048)

* [add] 좋아요 상태 체크  기능 추가

(cherry picked from commit 362c4a9f378e952db8bf46b0cc81baf0b8287e2f)

* [refactor] refactoring comment repo and add error case

(cherry picked from commit 5a020ea5c21501c018eecd6e4e0d62e91f7661c7)

* [fix] remove remark

(cherry picked from commit df07a4775101ad2e7d9598a0d375986f5bf9c647)

* [fix] user id to email in post controller:

(cherry picked from commit ca9e1e93ff93eb97f91beea013f345a047155604)

* [add] comment email url and add exception handling

(cherry picked from commit 815b1aaed61e590a7aea5350db6ccc6b9a483e57)

* [add] check enabled

(cherry picked from commit 3cab4a240118a2ae392f535d742052e515643898)

* [add] get user's all post

(cherry picked from commit 79c4ee07681136894a48f43cd3df91df93b88d86)

* [refactor] user controller and add resending verification email

(cherry picked from commit 954a4c3c616cf3514a1e3cc2aff5568b440c8420)

* [refactor] like controller

(cherry picked from commit 4d5baa05548c12fb593ca5dddc3635a97682eccc)

* [fix] change innter fetch join to left outer fetch join

(cherry picked from commit aead5df544b255ebb0030ccb747673b1d5a6d2fa)

* [modify] 나의 게시글, 분야별 게시글 최신순 정렬

(cherry picked from commit c4a68d44d444f81ecab87ad17b43f36e2ff0d6d7)

* [modify] modify cors (allow all headers)

(cherry picked from commit 2d02f9cfb0d709936cead7a54c35c80d3132a893)

* [fix] fix Like State

(cherry picked from commit dd6f52ac72cf753cc2364186f84f5b923dfc6101)

* [modify] get all post 방식을 findALL로 변경

(cherry picked from commit d8f3ed071135b6945c725d81a3bfa8a4fa7dfeaa)

* feat: swagger-API 도입 (#47)

* Changes by seyeon

* test: PostService like test 추가

환경분리 필요

* refactor: like 패키지 삭제 로직 이동

* refactor: 코드 정리

* feature: 테스트 동작을 위한 local환경 설정 분리

* feature: ControllerAdvice 도입하기 (#50)

* feature: ControllerAdvice 도입

* feature: Error 패키지 구조 수정 및 ErrorMessage 형식으로 응답 json 설정

* feat: CustomException 추가

* feat: UsernameNotFoundException 핸들링 추가

* refactor: exception 을 throw 하도록 수정

* Update README.md

* feature: api 회의 수정 사항을 반영한다. (#54)

* refactor: post api 주소 수정

* refactor(post): 메소드 소문자로 시작

* refactor: url likes->agreements

* refactor: comment api 주소 수정

중복되지만, posts/postId 부분을 공통으로 작성. (정답은 없겠지만, 각각의 메소드에서 가독성이 더 좋다고 판단)

* refactor: answer api 주소 수정

* refactor: user api 주소 수정

* refactor: 기본 CRUD 전략에 대해서는 해당 순서대로 배치 진행

* refactor: fileUpload api 수정

* feature: Comment 부분 기능 추가 및 리팩토링 진행 (#59)

* refactor(Comment): Builder 패턴 제거 및 id로 저장

* refactor(Comment): postId를 가지고 있도록 수정

* Changes by chlee

* refactor(Comment): content null 검증 삭제

* refactor(CommentRequest): CommentRequestDto -> CommentRequest

* refactor(CommentController): createComment 리턴하는 자료형 ReponseEntity<Object>->ResponseEntity<Void>, pathVariable 이름 변경 id->postId

* refactor(CommentController): getCommentsByPostId 에 대한 성공하는 테스트 작성

* test: getComments 정상 테스트 작성

* feat: 존재하지 않는 post의 comment 요청시 에러 발생

* Changes by seyeon

* feat(Comment): update 기능 추가

Co-authored-by: gurunelee <dlckdgk4858@gmail.com>
Co-authored-by: grace_goose <choieungi@gm.gist.ac.kr>

* fix: 동작하지 않는 테스트 수정 및 Comment api 주소 수정 (#61)

* fix(UserServiceTest): CustomException 으로 수정

* chore: Loggin level 추가 (생성 되는 테이블 정보 로깅)

* fix(PostServiceTest): Agreement를 직접 먼저 삭제해주고, Post 객체 삭제

* fix(CommentController): api 주소 오류 수정

* refactor: Entity의 Primary key 모두 id로 수정. -> primary key임을 id만 보더라도 인지할 수 있음.

* feat: github action for CI (#63)

* feat: CD  도입 (#65)

* feat: CD 파일 구성

* feat: 자동 배포 스크립트 작성

* feat: cd workflow 수정

* fix: erase path .

* fix: . -> sh

* fix: 잘못된 콤마 삭제

* refactor: srcipt 부분 수정

* fix: sh -> ./

bash shell 로 실행

* refactor: script

* refactor: stdout, stderr to file

* feat: develop 브랜치 push 조건 추가

* fix: 잘못된 위치 수정

* feature: agreement 동의 기능 요구 사항 수정 (#62)

* refactor: like -> agreement

* feat: 동의를 한 번만 진행할 수 있고, 한번 더 요청 시 400에러를 띄운다. 이에 해당하는 테스트 코드 작성

* feat: getNumberOfAgreement와 StateOfAgreement 구현

* Changes by seyeon

* reformat: formatting

* test: getNumberOfagreement와 getStateOfagreement Test Code 작성

* refactor(PostService): IllegalArgumentException -> CustomException 변경

* refactor: 메소드 명 변경 getStateOfAgreement -> isAgreedBy, postrepo.findbyId 공통 부분 메소드로 분리

* test(PostServiceTest): 코드 공통 부분 분리

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* feat: Entity가 BaseEntity를 상속 받도록 수정 (#70)

* feat: BaseEntity 도입 및 Post 생성 테스트 검증 추가

* Changes by choeeungi

* refactor(postController): return type 정의

* refactor(PostService): createPost 리턴 값 Long으로 복원

* feat: UnmodifiableEntity 추가 -> 수정 불가능한 경우 생성 시간만 데이터베이스에 저장하기 위함

* refactor(answer): 기존의 Answer 도메인에 관련된 CRUD 로직을 수정한다 (#72)

* refactor: Answer entity 칼럼 수정

* refactor: createAnswer & chore

* answerRepository의 findByCatecory 메소드 삭제

* feat : use role 에 MANAGER 추가

* feat : creatAnswer 검증로직 추가, 테스트 추가

* refactor : Answer 생성자 수정

* refactor : private 메서드 위치 변경

* refactor : retrieveAnswer 로직 수정

* feat : getNumberOfAnswers 컨트롤러 구현

* Changes by koseyeon

* fix : throw exception 삭제

* refactor : updateAnswer 로직 및 테스트 구현

* refactor : deleteAnswer 로직 및 테스트 구현

* feat: admin에게도 답변 수정 및 삭제 권한 부여

* fix: import 오타 수정

Co-authored-by: netai <netai@netaiui-MacBookPro.local>
Co-authored-by: gurunelee <dlckdgk4858@gmail.com>

* feat: Bean Validation 도입 (#77)

* refactor: 코드 포맷팅

* refactor: DTO에 대한 용어 통일 진행

* feat: post에 validation 도입

* feat: comment에 validation 도입

* feat: answer에 validation 도입

* feat: RegistrationRequest에 validation 도입

* chore: 학습 test용 test 삭제

* refactor: Spring Security를 걷어낸다. (#80)

* refactor: signUp 기본 로직 구현

* refactor(userService): userService 전체 로직 구현

* refactor: UserController 연결 및  enabled 옵션 추가

* refactor: spring security 제거

* chore: dummy-user(ADMIN권한) 추가 (#84)

추가로 swagger api 설정 조금 수정했습니다

* chore: swagger host 설정 추가 및 api 경로 수정 (#86)

* fix: swagger host 설정 추가

* chore: profile 설정 수정

* fix: cd pipleline - dev-deploy.sh (#87)

* feat(encryptor): password 암호화를 위한 encoder 클래스 구현 (#83)

* feat : impl password encryptor with jbcrypt

* refactor : remove comment

* feat : BcryptEncoder test code

* refactor: 코드 정리

Co-authored-by: Wannte <T.wannte@gmail.com>
Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* fix: 인가 정책 수정 (#89)

* fix(comment): 권한 수정

* fix(answer): 권한 수정

* fix(post): 권한 수정

* test: 인가 정책 변경에 따른 테스트 수정

* feat: 이메일 인증 구현 (#91)

* feat: VerificationToken과 테스트 구현

* feat: VerificationToken confirm 기능 구현

* feat: VerificationToken 생성 기능 및 이메일 전송 기능 구현

* refactor: VerificationToken에서 userId를 받도록 변경

본래 User를 받아서 OneToOne 관계를 가졌지만, foreign key 제약으로 인해 delete에서 여러 제한이 걸리는 여러 어려움이 있어서 userId를 받도록 변경했습니다.

* feat: Event 방식으로 이메일 전송 기능 도입

* refactor: verification 패키지 분리

* refactor: 코드 정리 및 역할에 따른 코드 위치 이동

Co-authored-by: Wannte <T.wannte@gmail.com>

* feat: session 기반의 인증/인가 구현 (#90)

* feat : SignInRequest, UserController.login, UserService.signIn 구현

* feat : UserService 의 signIn() 에 대한 테스트코드 구현

* refactor: fakeUsername , facePassword 내용을 이해하기 쉽게 바꿈.

* refactor: SessionUser에 enabled 필드를 추가.

* refactor: AnswerController, CommentController, PostController에 SessionUser를 세션저장소로 부터 꺼내와서 권한체크하는 로직 구현, 기존에 컨트롤러들에 있던 ADMIN은 삭제하고 DataLoader에 있던 ADMIN을 private로 변경.

* feat: logout 컨트롤러 구현.

* refactor: <진행중> 권한 체크를 서비스 단이 아닌 컨트롤러 단에서 하도록 리팩토링.

* refactor: post 에 대한 권한 체크를 서비스 단이 아닌 컨트롤러 단에서 하도록 리팩토링.

* refactor: AnswerService에서 더이상 사용하지 않는 메소드 삭제

* refactor: answer, comment CRUD 권한 체크 로직 변경에 따른 test 코드 변경

* refactor: PostController에 updatePost 컨트롤러 추가, 권한 체크 부분이 컨트롤러로 넘어감에 따른 PostServiceTest 변경.

* refactor: session invalidate 도입 및 형식 통일

Co-authored-by: gurunelee <dlckdgk4858@gmail.com>
Co-authored-by: Wannte <T.wannte@gmail.com>

* refactor: Comment 인가 분리 및 테스트 리팩토링 (#93)

* refactor: comment 인가 정책 수정

* refactor: postServiceTest 수정

* refactor: AnswerService 수정 및 delete 로직 setAnswered(false)

* refactor: CommentServiceTest 상수 처리

추후에 CommentRequest의 형태가 변화하더라도, 테스트 유지 보수가 쉬워지기 위함.

* fix(CommentController): early 리턴 적용해서 서비스 로직이 한 번만 타도록 적용

* test: post 작성자와 댓글작성자 분리

* refactor(postService): post를 조회하고 사용하지 않는 부분 수정. 존재 유무만을 확인

* fix(deletePost): true,false 반대로 된 부분 수정

* feat: User 권한 정책 구현 (#100)

* feat: user 조회 api 인가 정책 추가 : admin만 조회 가능

* feat: 개인정보 조회를 위한 `POST /users/me` api 추가

Response를 User에서 가공을 하여 보여주는 부분을 수정할 필요가 있음.

* feat:  유저 삭제 권한 추가 및 `DELETE /users/me` api 추가

* feat: 유저 자신의 패쓰워드 수정 기능 구현

`PUT /users/me/password`
SignUpRequest의 유효성 검증 부분 추가

* feat: 유저 권한 수정 기능 추가

admin, Admin, ADMIN 과 같이 다양한 요청에 대해서도 기능이 동작해야 한다고 판단하여 `ignoringCaseValueOf()`메소드를 구현하여 해결

* feat: 자신의 계정 삭제시 패쓰워드 필요

* fix: admin 의 password 를 암호화한다 (#104)

* refactor: dev profile을 삭제하고, 외부에서 프로파일을 주입하도록 함. (#96)

* feat: dev profile에 datasource(Mysql), jpa 연결 설정 추가.

* refactor: application.yml에서 'dev' profile 삭제

* refactor: application.yml에서 dev용 swagger설정 부분 삭제

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* refactor: post의 id 생성전략 수정.

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* feat: 수정된 회원가입 방식 반영 (#108)

* feat: 회원 가입 정책에 쓰일 인증 코드 생성

* feat: 회원 가입 정책 용어 변경 및 테스트 추가

* feat: verification code를 confirm하는 기능 구현

* refactor: confirmed column 삭제 및 테스트 구현

* feat: sign up 기능 구현 및 테스트 작성

* feat: SignUpValidator Test 작성

* refactor: user domain에서 enabled column 제거, 기존 이메일 인증 방식 제거

* refactor: VerificationToken domain 제거

* refactor: email-verification2.html -> email-verification.html

* refactor: token -> verificationCode

* refactor: post,answer,comment의 작성 내용의 저장 타입을 clob으로 수정 (#107)

* feat: CustomException 을 계층화한다 (#99)

* feat: custom exception 중 post 도메인에서 던지는 예외를 클래스화 하였다.

* revert: 테스트용 post exception 들을 삭제한다

* feat: ApplicationException 을 정의한다

* feat: exception/post 를 정의한다

* feat: exception/user 를 정의한다

* feat: exception/comment 를 정의한다

* feat: post 도메인에 계층화된 exception 을 적용한다

* refactor: UnAuthenticatedUserException 의 이름을 NotConfirmedEmailException 으로 바꾼다

* feat: answer 도메인에 계층화된 exception 을 적용한다

* feat: comment 도메인에 계층화된 exception 을 적용한다

* feat: user 도메인에 계층화된 exception 을 적용한다

* refactor: validation 에 계층화된 exception 도입

* refactor: ControllerAdvice 에 ApplicationException handler 구현

* refactor: CustomException 수정

CustomException 이 CheckedException 과 메시지, httpStatus 를 담을 수 있도록 수정. 기본 HttpStatus 는 400 (Bad Request)

* feat: RegistrationListener 에 계층화된 exception 도입

* chore: import 추가

* feat: AnswerServiceTest 에 계층화된 exception 추가

* feat: 변경된 CustomException 적용

* refactor: VerificationServiceTest 에 놓친 exception 반영

* refactor: post 도메인에 적용된 exception 세분화

* fix: after resolving conflicts...

* refactor: remove ErrorCase.java, ErrorMessage.java

* refactor: rename CustomException to WrappedException & let WrappedException inherit ApplicationException

* feat: add exception group of verification domain

* feat: exception 에 http status code 추가

* feat: NoSessionException 추가, 각 Controller에 적용

* refactor: rename NoSessionException to UnAuthenticatedException (#114)

* refactor: rename NoSessionException to UnAuthenticatedException

* refactor: 코드 컨벤션 적용

* feat: Error메시지 payload를 json 형식으로 수정한다. (#115)

* feat: Error메시지 payload text->json

* refactor: WrappedException ExceptionHandler 구분

* refactor: Post 삭제 시 이벤트 방식으로 댓글, 답변 삭제 (#117)

* refactor: Post 삭제 시 댓글, 답변 삭제. findByPostId() 메소드를 사용하도록 리팩토링

* refactor: 모호한 메소드 명 수정 PageNumber -> PostCount

* chore: cors origin 지정 (#120)

* chore: cors origin http 추가 (#121)

* chore: cors origin allow credentials (#122)

* refactor: cookie config (#123)

* refactor: application.yml에 cookie 설정 추가.

* refactor: cors 설정 변경 - allowedOrigin에 URL https://dev.gist-petition.com 추가.

* fix: swaggerConfig- protocol를 https로 변경, EmailSenderImpl이 적용되는 프로파일목록에 dev 추가. (#126)

* fix: javaEmailSender를 찾지 못하는 문제 해결 (#127)

* fix: swaggerConfig- protocol를 https로 변경, EmailSenderImpl이 적용되는 프로파일목록에 dev 추가.

* fix: swaggerConfig- protocol를 http로 롤백, javaMailsender를 찾지 못하는 문제를 해결하기 위해 javaMailsenderImpl을 빈으로 등록.

* fix: fakeEmailSender를 삭제하고 test에 mockbean으로 emailsender를 등록하여 해결. (#130)

* fix: MailConfig로 설정해주었던 부분을 삭제한 후 관련 설정이 프로파일별로 관리되도록 함 (#131)

* fix: 로컬 테스트를 위해 cors 허용출처에 https://localhost:3000 를 허용 (#134)

* fix: 로컬 테스트를 위해 cors 허용출처에 https://localhost:3000 를 허용

* fix: 로컬 테스트를 위해 cors 허용출처에 https://127.0.0.1:3000 를 허용

* feature: verificationInfo를 하나만 가질 수 있도록 갱신 로직 추가 (#136)

* feat: verificationInfo를 발급받았을 때, 기존의 verificationinfo를 삭제

* test: verification 갱신 테스트 추가

* feat:  interceptor/argumentResolver를 활용하여 인가 정책을 구현한다. (#124)

* feat: LoginInterceptor 구현

* feat: LoginUserArgumentResolver 구현

* feat: interceptor, argumentResolver 등록

* refactor: PostController interceptor&argumentResolver 도입

* refactor: CommentController interceptor&argumentResolver 도입

* refactor: AnswerController interceptor&argumentResolver 도입

* refactor: package 이동

* feat: admin, manager권한에 대한 인터셉터 구현

* refactor: Answer, Post Controller `@ManagerPermissionRequired` 도입

* refactor: UserController interceptor&arguementResolver 도입

* refactor: LoginService,LoginUser 분리해서 구현

* refactor: 로그인 관련 로직 LoginService로 이동

* feat: User BaseEntity를 상속 받도록 수정

* refactor: LoginUser 인터페이스 삭제 후 SimpleUser 통일 진행

* fix: 인터셉터 기본 true로 수정

* feat: same-site None 옵션으로 설정 (#139)

* fix: SignInRequest No Args 생성자 추가

* feat: SameSiteFilter 구현

* refactor: User -> UserResponse (#140)

* refactor: 패키지 구조 정리 (#142)

* refactor: Answer 패키지 리팩터링

* refactor: Comment 패키지 리팩터링

* refactor: config 패키지 리팩터링

* refactor: post 패키지 리팩터링

* refactor: user, common 패키지 리팩터링

* refactor: verification 패키지 리팩터링

* refactor: 전체 패키지 경로 수정

* refactor: application 이름 수정

* refactor: swagger base package

* refactor: utils 패키지 분리

* feature: submodule 을 도입하여 민감정보를 분리한다. (#143)

* feat: gitignore 에 application-dev.yml 추가

* feat: server-privates을 submodule로 추가

* feat: server-privates 의 파일을 불러와서 설정파일로 사용

* refactor: 중복된 설정 제거

* refactor: cors origin yml에서 입력하도록 수정

* refactor: profile 병합

* chore: datasource, mail 이동

* chore: CI,CD에 서브모듈 반영

* chore: dev 용 database 이름 변경

Co-authored-by: koseyeon <koseyeon97@gmail.com>

* fix: dev profile에 메일 설정 추가 (#144)

* feature: verification code 랜덤 생성기 구현 (#146)

* feat: 랜덤 6자리 verification code 생성기 구현

* feat: 랜덤 6자리 verification code 생성기 구현

* refactor: 상수처리

* feat: Loggin 전략 도입 (#147)

* feat: ControllerAdvice 로깅 추가

* feat: logback 설정 추가

* chore: 자동으로 설정되는 jpa.database-platform 삭제

https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html 참고

* chore: docker-compose submodule 반영

* refactor: 무의미한 엔터 제거

Co-authored-by: ChangHa Lee <60911416+GuruneLee@users.noreply.github.com>

* feat: post pagination 기능 추가 (#148)

* feat: post pagination 기능 추가

* feat: NoSuchCategoryException 추가

* refactor: Post 응답에 PostResponse 가 쓰이도록 수정

* chore: 초기 post 200개를 생성한다.

* fix: PostResponse에 시간 추가 (#151)

* fix: PostResponse에 시간 추가

* fix: PostResponse 값 수정

* fix: dev profile에 스웨거 설정 복구 (#152)

* feat: api 로깅 추가 (#154)

* fix: access logger 수정 (#155)

* feat: post 제목으로 검색할 수 있는 기능 구현. (#162)

* fix: log4j 이슈 대응 (#167)

* refactor: Post 도메인 명칭을 Petition으로 변경한다. (#163)

* refactor: post -> petition 리팩토링 진행

* chore: sql문 삭제

* refactor: Petition 수정되지 않은 부분 진행

* chore: 사용하지 않는 설정 삭제 및 gitignore 수정

* chore: getCommtnetsByPetitionId 메소드 코드 정리, login의 transaction에 readOnly=true 설정 (#173)

* refactor: 청원목록을 반환하는 경우 PetitionPreviewResponse를 반환하도록 수정 (#179)

* feat: PetitionPreviewResponse 생성, 청원리스트를 반환하는 API들의 경우 PetitionPreviewResponse를 반환하도록 수정.

* refactor: page 클래스의 map 메소드를 활용하여 page에서 DTO를 뽑아내도록 수정

* feature: 비밀번호 찾기 기능 구현 (#175)

* feat: VerificationInfo 상속 및 VerificationType Enum 구현

* refactor: Verification -> SignUpVerification

* refactor: SignUpValidator package를 user에서 verification으로 이동

* feat: FindPasswordValidator 구현

* refactor: signup과 password package 분리

* feat: FindPasswordVerificationService 구현

* fix: VerificationInfo -> SignUpVerification type 변경

* fix: VerificationInfo 부모 타입이 아닌 정확한 타입(SignUpVerificationInfo, PasswordVerificationInfo)로 변경

* refactor: Event에 대한 정보를 parameter로 받도록 변경

* feat: findPasswordTest 작성

* feat: /users/reset-password 기능 구현 및 테스트 작성

* feat: 비밀번호 인증 메일 html 작성

* refactor: 변수명, 파일명 변경과 @BeforeEach 분리

* feature: 인수테스트를 만들었다 (#174)

* feat: rest-assured 의존성 추가

* feat: 회원가입 시나리오의 api 콜 테스트를 작성하였다

* feat: 로그인 시나리오 api test 추가

* feat: FixedVerificationCodeGenerator 를 추가하여, 테스트시 verification code 가 'AAAAAA'로 고정되게끔 한다

* feat: test 프로파일에서만 작동하는 TestDataLoader 를 정의하였다

* remove: 기존 UserAPITest.java를 삭제한다

* feat: 인수테스트를 위한 TUser와 LoginAndThenAct를 구현하였다

* feat: TestDataLoader에서 저장한 Admin 정보를 가지고있는 FirstAdmin을 구현하였다.

* feat: 인수테스트 중 CreatePetitionAcceptanceTest 을 구현하였다.

* fix: SignUp 관련해서 변경된 Naming들을 테스트코드에도 반영

* refactor: test 관련된 파일을 test 패키지로 이동

* refactor: 인수테스트 구조 변경

* refactor: FixedVerificationCodeGenerator 위치 변경

* refactor: randomPort 할당 부분 따로 분리

* refactor: rest assured api 콜에서 log().all() 삭제

* feat: rest assured 버전을 4.4.0으로 수정한다

Co-authored-by: koseyeon <koseyeon97@gmail.com>

* chore: admin 페이지를 위한 3001 port open (#187)

* fix: 어드민용 유저 조회시 id를 같이 반환하도록 수정 (#188)

* feat(Answer): 청원 답변 기능 history를 남기도록 수정 (#181)

* feat(Answer): Answer Entity 변경 이력 기록 기능 구현

Answer가 삭제되었을 때에도 이력이 보여야 하기 때문에 다른 메서드의 petitionId를 통한 조회가 아닌 answerId를 통해 조회를 진행

* feat(Answer): Controller 로직 구현

* fix: deleteAnswer 오타 수정

* feat(Answer): Answer createdBy, modifiedBy 기능 구현

해당 api를 실행하는 simpleUser의 id를 기록.
Revision이 기록되는 시점에서의 수정자를 revision에 기록하는 것이 더 자연스럽다고 생각.
지금의 구현에서는 삭제한 사람을 알 방법이 없음 -> 다음 두 가지의 해결 방법이 가능

1. soft삭제를 도입하게 되면 이 문제를 해결할 수 있음
2. customRevision 객체를 만들고 기록을 하도록 설정

* feat(RevisionEntity): RevisionEntity 작업자 추가 및 userId 추가

작업자의 ID의 기능 추가를 진행했고, 기본 id의 제한 값을 int에서 long으로 수정을 진행

createdBy, updatedBy 가 모든 revisionEntity에 저장되는 것은 revision의 userId의 추가와 중복된 로직이라 생각되기 떄문에 삭제를 진행해도 좋을 듯.

* test: answer revisionType 검증 로직 추가

* refactor: JpaConfiguration 분리

패키지 위치로 인해, basePackage를 지정하지 않게 되면 Bean등록에 문제가 발생해서 별도로 지정해줬습니다

* refactor: Auditor 로직 삭제

* chore: DataLoader 에서 청원 등록 로직 삭제

* fix: petition의 제목,카테고리도 수정 가능하도록 수정. (#190)

* fix: petition의 제목,카테고리도 수정 가능하도록 수정.

* test: 카테고리 하드코딩 수정 및 update 필드값 검증

* refactor: Category의 getById 메소드명을 of로 변경 및 CategoryTest 추가

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* feat: 답변된 answer api 추가 (#192)

* feat: cors expose header 문제 해결 (#193)

* feature: Agreement에 desciption 추가 구현 (#183)

* feat: agreement에 description field 추가 및 테스트 작성

* feat: 존재하지 않는 포스트에 동의 Test 추가

* refactor: remove comment package

* refactor: remove comment test

* refactor: 청원 동의 개수 URI 변경

* feat: 모든 청원 동의 불러오기 기능 구현

* feat: Agreement 양방향 변경 및 리뷰 반영

* feat: `@BatchSize`를 이용해 N+1 문제 해결

* refactor: get -> retrieve

Co-authored-by: ChangHa Lee <60911416+GuruneLee@users.noreply.github.com>

* fix: prod 환경에서 민감정보 로깅 되지 않도록 수정 (#195)

* refactor: LogConfig 분리 및 starter 의존성 삭제

logback의 의존성을 주입했을 때 해결이 되기에 불필요한 의존성이라 판단하고 삭제, TeeFilter를 통해서 더 자세한 로깅을 제공하는데(request,response의 모든 데이터)

* fix: local에서 어플리케이션 실행을 위한 FixedVerificationCodeGenerator 위치 이동

* chore: 기존의 의존성을 유지하는 방식으로 결정

* refactor: Timezone 설정 Spring에서 진행하도록 수정 (#197)

* chore: VerificationType 오타 수정

* feat: Timezone `Asia/Seoul` default 설정

script에서 진행하던 부분을 Spring의 `@PostConstruct`를 통해 진행.

* chore: 기존의 dev-deploy.sh timezone 설정 삭제

* refactor: AgreementResponse 구조 수정

* refactor: `@Data` 어노테이션으로 Response 통일

* feat:petitions-history 구현 (#194)

* feat: petition Revision 기능 구현

* feat: retrieveRevisionsOfPetition 테스트 작성

* refactor: agreements에 대해서 아예 감사를 하지 않도록 수정

* fix: 유저 조회시 암호화된 패쓰워드가 보내지는 부분 수정 진행 (#199)

* fix: Admin 유저 조회 요청시 UserResponse 사용 & 페이지네이션 도입

* chore: AcceptanceTest 환경 설정 분리

* test: 조회 테스트 구현

* chore: 프론트엔드 측 회원 가입 로직 테스트를 위해 api 추가 및 인증 시간 수정 (#204)

* feat: username으로 user 삭제하는 api 임시 구현

* chore: 테스트를 위해 Verificiation 시간 정보 임시 수정

* test: 임시 변경으로 인한 테스트 깨진 부분 수정

* chore:petitions-history 테스트에 설명 추가 (#200)

* feat: petition Revision 기능 구현

* feat: retrieveRevisionsOfPetition 테스트 작성

* refactor: agreements에 대해서 아예 감사를 하지 않도록 수정

* chore: retrieveRevivionsOfPetition Test에 설명 추가, num 비교할때 equals를 쓰도록 수정

* refactor: Petition Agreement 양방향 설정 (#202)

* feat: Petition, Agreement에서 연관 관계 주인이 저장하도록 구현

* feat: petition을 지울 때 Agreement도 지우는지 테스트 추가

* refactor: 필요없는 field 제거

* feat: Batchsize Test 추가

Co-authored-by: ChangHa Lee <60911416+GuruneLee@users.noreply.github.com>

* feat: 동시에 여러 동의 요청시 하나의 동의만을 허용하는 기능 구현 (#208)

* test: 다중 스레드 환경 동의 요청 테스트 추가

* feat: UniqueConstraint를 추가하여 각 청원에 하나의 동의만 허용하도록 수정

트랜잭션이 커밋되는 시점에 에러가 발생하게 되는데, 이를 어떤 어플리케이션의 에러로 핸들링할 방법에 대해서 고민이 필요.(서비스 안에서는 에러를 업그레이드 불가)

* test: 두 번 동의 시 에러 발생 로직을 서비스레이어에서 검증

기존에는 도메인 레이어에서 직접 동의 리스트를 순회하면서 검증을 진행했지만, 지금의 구현에서는 트랜잭션 레벨의 디비 유니크 조건으로 검증을 진행하기 때문에 테스트의 위치 이동

* feat: Controller에서 Appllication 예외 전환 로직 구현

* feat: dev-ddl create-drop으로 수정 및 dev data setting api 추가 (#212)

* chore: create-drop 으로 dll-auto 수정

* feat: data-setting api 추가

* chore: DataLoader 값 추가

* feat: 사전 동의 기능 구현 (#205)

* feat: 사전 동의 기능 구현

* fix: merge 후 꺠진 테스트 수정

* chore: 메소드명 수정 ( petitionsTocheck -> TempPetitions )

* fix: TempPetition을 가져올 때 사전동의수가 채워졌고, 노출 또한 되지 않은 것들을 가져오도록 수정

* feat: petition 에 UUID 필드 추가 및 petition을 uuid로 접근해서 조회하는 로직 구현.

* chore: import 추가

* fix: agreeCount를 Enver가 추적하지않도록 수정

* refactor: retrievePetitionWatingForCheck 테스트 리팩토링 및 관련 메소드명 변경

* refactor: CreatePetition 시 Petition의 UUID를 반환하도록 변경

* Revert "feat: 사전 동의 기능 구현 (#205)" (#214)

This reverts commit b37367367e3cdfaff71cd3830ba1dbb5899fe799.

* refactor: request DTO validation 정리 및 테스트 작성 (#209)

* refactor: validation annotation 통일 (@Email, @NotBlank)

* refactor: @NotBlank 는 CharacterSequence 에만 적용할 수 있다.

* refactor: VerificationController 에 @Validated 추가

* refactor: 인수 테스트 메서드 구현 변경

* feat: bean validation 동작 테스트

* refactor: optimize import

* feat: 서버 기본 locale 을 Local.KOREA 로 설정

* feat: bean validation locale 을 Local.KOREA 로 설정

* chore: dev-staff 도메인 추가 (#215)

* feat: AnsweredPetition 조회 기능 구현 (#218)

* feature: Temp Url 기능 구현 진행 (#216)

* feat: URL generator 구현

* feat: TempPetition 기능 구현

* feat: TempPetitionResponse 구현

* fix: while 문 삭제

무한 루프가 돌 가능성이 있는 부분 삭제.

TempUrl이 한 개만 존재하는 알고리즘을 고민할 필요가 있음. 지금의 구현에서는 실패한 요청으로 나와서 새로 청원을 생성하도록 시나리오가 구성됨.

* refactor: serviceTest 상속으로 변경

Co-authored-by: grace_goose <choieungi@gm.gist.ac.kr>

* chore: DataLoader 답변 데이터 추가 (#219)

* refactor: 청원 동의 Exception upgrade 위치 수정 (#224)

* refactor: 청원 동의 Exception upgrade 위치 수정

* test: 에러 나는 테스트 수정

* feature: 한명의 유저가 동시에 answer를 생성 할 경우에 대한 테스트 작성. (#217)

* feat: answer 중복 방지 구현

* chore: import 삭제

* refactor: 인수테스트 함수 다듬기

* revert: 기존 createAnswerWithConcurrency 테스트 삭제

* feat: 인수테스트에 createAnswerWithConcurrency 테스트 추가

* fix: 인수테스트 사이 데이터 정합성 문제 해결

* revert: ValidationTest 삭제 ㅠ

* refactor: CreateAnswerAcceptanceTest 동시성 테스트 변경

* feat: mock HttpSession 에 대해 AnswerServiceTest 동시성 테스트 추가

* chore: optimize import

* feat : AnswerService.createAnswer 에서 DataIntegrityViolationException 을 DuplicatedAnswerException 으로 업그레이드

* feat : tempPetition 을 거치는 createPetition인수 테스트 구현

Co-authored-by: koseyeon <koseyeon97@gmail.com>

* feature: 청원 release 기능 구현 (#221)

* feat(Petition): release 기능 구현

* feat(PetitionService): releasePetition 기능 구현

* feat(PetitionController): release api 구현

* fix: Eager 로딩 제거

* feat: concurrent-user test 구현 및 latch에 대해 finally에서 countDown해주도록 한다. (#225)

* feat: concurrency user test 구현

* feat: signUp시의 exception을 바꿈.

* refactor: CreateAnswerWithConcurrencyTest 에서 에러 갯수에 대한 검증도 진행한다.

* refactor: createAnswerWithConcurrency Test에서 에러 갯수에 대한 검증도 진행한다.

* refactor: applyAgreementWithConcurrency Test에서 에러 갯수에 대한 검증도 진행한다.

* refactor: finally에서 latch의 countDown을 하도록 수정한다.

* feat: 청원 동의 수로 조회 기능 구현 (#229)

* chore: DataLoader 데이터 수정

* feat: Petition AgreeCount 추가

* feat: 동의 순 청원 조회 기능 구현

* feature: release된 청원만 조회 가능 하고, waitingForCheck api 구현 (#231)

* feat: 공개된 경우에만 id로 청원 조회 허용

* feat: 기본 조회에 경우 release 된 청원만 보여주도록 수정, 기존의 로직은 비교를 위해 `/petitions/all`로 우선 남겨두도록 함. (이후에 admin 권한으로 수정할 수 있을듯)

* feat: 매니저 권한의 waitingForCheck 기능 구현

* refactor: waitingForCheckPetitionCount 명시

* refactor: agreements.size() -> agreeCount 를 사용하도록 수정

* refactor: 공개되지 않은 청원 접근시 FORBIDDEN 상태코드 반환

* refactor: text-align center 변경 및 Shouting -> 지스트 청원 (#233)

* refactor: text-align center 변경 및 Shouting -> 지스트 청원

* fix: sample text 제거

* feat: released petition 인수테스트 작성 (#230)

* refactor: 사용하지 않는 userRepository 제거

* refactor: 사용하지 않는 userRepository 제거

* feat: agree user 생성

* feat: release petition 인수테스트 작성

* feat: release petition 인수테스트 작성

* fix: T_MANAGER를 통해 User 중복 생성 오류 해결

* refactor: method name 변경 및 리뷰 반영

* refactor: TempUrl을 Petition이 가지도록 수정 (#235)

* refactor: Petition tempUrl 필드 추가

* refactor: TempPetitionService 의존성을 제거

* refactor: TempPetition 관련 로직 삭제

* fix: petitionIds를 순회하도록 수정

* fix: Release된 경우만 count에 포함되도록 수정 (#234)

* fix: Release된 경우만 count에 포함되도록 수정

* refactor: released가 들어나도록 메소드 명 수정

* feature: Release 대기중, Answer대기중인 청원 갯수 조회 api, Answer 대기중인 청원 목록 조회 api 구현 (#237)

* refactor: released가 들어나도록 메소드 명 수정

* feat: waitingForRelease, waitingForAnswer 숫자 조회, waitingForAnswer 페이지 api 구현

* chore: DataLoader 수정. 답변되지 대기중인 청원 존재하도록 수정

* chore: ManagerPermission 복원

* feature: petitionRevision의 title, category 칼럼 추가 (#238)

* feat: 만료된 청원 조회 기능 구현 (#236)

* feat: 만료된 청원 조회 기능 구현

* refactor: 서비스 메소드명을 좀더 비즈니스적으로 변경

* feat: 청원의 응답으로 expired 정보 또한 넘겨준다.

* fix: posting_period 상수 추가

* feat : ongoing, expired 청원 불러오기 위한 release 메서드 생성 (user pool 생성)

* feat : DateTimeProvider mocking 을 통해 만료된 청원 생성 + 테스트 수정

* feat : setDateTimeProvider 를 필요한 테스트에서만 해주게 구현

* refactor: PetitionService에서 posting_period 상수를 import해서 사용하도록 수정.

* refactor: petitionService.retrieveExpiredPetition 메소드 명에 released를 추가하여 명확히 함.

Co-authored-by: gurunelee <dlckdgk4858@gmail.com>

* feat: 도메인과 DB 레이어를 분리한다. (#242)

* refactor: id를 BaseEntity 와 UnmodifiableEntity 로 이동.

* feat: 만료된 청원에 동의 실패하는 테스트 추가.

* feat: add agree 메서드 시간 의존성 제거. Service layer 로 올림.

* feat: release 메서드 시간 의존성 제거. Service layer 로 올림.

* refactor: /petitions/ongoing으로 접근시 공개된 청원중 답변되지 않은 청원들을 불러오도록 함. (#248)

* feature: AOP를 활용하여 DataIntegrityViolation 관점을 분리한다. (#244)

* feature: aop를 활용하여 DataIntegrityAspect 관점 분리

* feature: user, answer에도 DataIntegrityHandler 적용

Co-authored-by: koseyeon <koseyeon97@gmail.com>

* feature: milisecond로 시간 정보를 보내준다. (#246)

* chore: LocalDateTime 사용 부분 Instant로 수정

* feat: mili seconds 단위로 response 보내두도록 수정

Co-authored-by: koseyeon <koseyeon97@gmail.com>

* feat: retrieveAnsweredPetitionCount 기능 추가. (#251)

* refactor: Query,Command Controller 분리 및 api 권한 수정 (#252)

* chore: 사용하지 않은 api 삭제

* chore: /petitions/all amdin 권한 부여

* chore: revision 조회 기능 Manager 권한으로 수정

* refactor: Query, Command Controller 분리

* refactor: 답변 수정 이력 매니저 권한으로 수정

* chore: DataLoader 데이터 추가 (#253)

* chore: Dataloader 데이터 추가

30초 후에 만료되는 데이터 또한 추가

* chore: created Location에 v1 추가

* chore: sign-up 프론트 개발을 위해 뚫었던 api 삭제

* feature: released 된 청원 전체 조회 기능 구현 (#254)

* feat: release된 청원 조회 기능 구현

* chore: Petition Service 사용하지 않는 메소드 삭제

* chore: PetitionPreviewResponse, PetitionResponse 에 released, answered 정보 추가

* chore: 김건호를 위한 300 동의 청원 생성. 필요없어지면 지움. (#257)

* feat: flyway 도입 (#255)

* feat: spring boot flyway 의존성 추가 및 기본 설정 dev profile 에 추가

* feat: resource/db/migration 에 V1__init.sql 추가 (기존 테이블 ddl 스크립트 기입)

* refactor: naming convention 을 지키기 위해 수정했다. 만약 이미 적용되어 있다면, db에서 flyway table 을 삭제하고 앱을 실행해야한다.

* refactor: default 값은 명시하지 않는다

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

Co-authored-by: wannte <49307266+wannte@users.noreply.github.com>

* feature: 청원 승인 취소 기능 구현 (#262)

* feat: cancel Release 기능 구현

* refactor: PetitionService 메소드 분리

* refactor: PetitionTest 메소드가 그 의미를 명확히 들어내도록 수정

* feature: prod server 세팅 (#263)

* chore: project 이름 수정 및 deploy script 수정 및 prod 생성

* chore: deploy 위치 이동 및 CI,CD 수정

* chore: build.gradle java 버전 지정

* chore: prod-CD 생성 및 분리

* chore: mail prod,dev 분리

* chore: prod sameSite 설정

* chore: application-prod 삭제

* refactor: 사용하지 않는 file 패키지 삭제

* fix: SameSiteFilter 문법 오류 수정

* chore: DEV_HOST, PROD_HOST 지정

* feat: 백엔드 readme 업데이트 (#265)

* feat: 백엔드 readme 업데이트

* feat: 기술 스택 추가

* feat: 프로필에 블로그 연결되는 로고 추가

* refactor: github, techblog 로고 링크 연결

* fix: CD 스크립트 수정 (#271)

(cherry picked from commit 9e3d423b3ca1842d4995ee0b2310bf9aeb65f0ae)

* feat: AgreementResponse에 createdAt 추가 (#272)

(cherry picked from commit 3999912aa8bfc14df51b19019c74f3f50d6b2891)

* chore: NotMatchedPasswordException의 메시지를 보다 명확히 함. (#274)

(cherry picked from commit 63db9e1a42614849a6300c77deda923701cbb008)

* feature: query dsl (#273)

* feat: gradle 의존 설정 추가

* feat: config 추가 및 QueryDslRepo 생성

* fix: querydsl 4.4.0으로 버전 변경

* feat: waitingForRelease와 waitforAnswer Querydsl작성

* fail : 안되는것.

* feat: PetitionCommandService, PetitionQueryService 분리

* chore: 이름을 어떻게 변경할지 고민하다가, 일단 주석으로 마킹

* feat: PetitionQueryCondition Predicate 으로 구현

* feat: onging, waiting for 등 petition 의 복잡한 쿼리를 querydsl 로 분리하였다.

* refactor: petition service interface 삭제

* refactor: PetitionQueryCondition

* refactor: categoryId -> Optional

* refactor: QuerydslPredicateExecutor 도입

* refactor: FallbackPageable Configuration에서 정의

Co-authored-by: gurunelee <dlckdgk4858@gmail.com>
Co-authored-by: wannte <T.wannte@gmail.com>
(cherry picked from commit 84dfff949c1071e484e8a6a1442b028b422c0e81)

* fix: 이메일 폼 수정 (#275)

* fix: 이메일 폼 수정

* refactor: 오픈 채팅으로 수정

(cherry picked from commit 4e705d7394db3cce5e98b0a61d2052d6f282c6e4)

* feat: petition 엔터티의 agreements 를 일급객체로 분리하였다. (#280)

* feat: List<Agreement> 의 일급객체로서 Agreements 를 정의하고 test를 작성하였다.

* feat: petition 에서 동의에 관한 로직은 Agreements 로 포함시켰으므로, petition test 에서 petition 의 역할을 넘은 검증을 제거하였다. 이에 fetch join 쿼리가 필요가 없어졌다.

* feat: Agreements 생성자를 protected 로 선언

* refactor: Agreements 네이밍 변경 및 테스트 단순화 (의도한 부분이 잘 보이도록)

* refactor: Agreements 네이밍 변경 및 테스트 단순화 (의도한 부분이 잘 보이도록)

(cherry picked from commit dd3363257995a882453d58677941224cc7809e8e)

* chore: default size to 10 (#284)

(cherry picked from commit 3246005bab48867fef04437d482235eea0ff81b9)

* fix: categoryId = 0 일 때 전체 조회하도록 수정 (#285)

지금의 Optional의 사용이 좋은 구현인지는 모르겠으나, 가장 쉽게 수정할 수 있어 유지했습니다.

(cherry picked from commit a420bdffee72958eb37a6b693b9e10551ad18418)

* refactor: Agreement `@OneToMany` 관계 Cascade설정 적용으로 단순화 (#282)

* refactor: Agreement CascadeType.PERSIST를 이용하여 구현

기존에 연관관계의 주인인 Agreement레포에 직접 넣어줬지만, 지금의 방식으로 수정했을 때 객체 지향적인 코드를 짤 수 있을 것으로 생각.

* refactor: petitionService agree 수정

flush되는 시점에 unique 에러가 발생하는데, 기존의 DataIntegrityHandler의 경우에는 Order 설정을 진행하지 않았었고 이는 Lowest_Precedence인 트랜잭션보다도 안쪽에서 시작되는 것으로 보인다.

특별한 의미는 없지만 Order(1) 옵션을 추가해줌으로써 이를 해결해줄 수 있었다.

DataIntegrityAspect -> T.begin() -> PetitionCommandService.agree() -> T.flush() -> T.commit() -> DataIntegrityAspect

* refactor: 사용하지 않는 repository 제거

* refactor: 사용하지 않는 메소드 삭제

(cherry picked from commit 25461f06466391132ecd6fb4529bf6dbc1a97776)

* refactor: mysql docker db로 test환경 구축 (#286)

* refactor: 사용하지 않는 메소드 삭제

* chore: local환경에서 docker mysql 사용하도록 설정

* refactor: AgreementsTest 패키지 위치 수정 및 가다듬기

* refactor: local환경에서 docker-mysql 사용 및 데이터 초기화를 테스트 전으로 이동

* refactor: rest-assured.sql 를 통해 인수 테스트도 수정

* refactor: setUp에서 admin, manager 기본 계정을 넣는 방식으로 수정

* chore: github serivce를 이용하여 CI 환경에서 mysql:8.0 사용

* chore: mapping 3306 port to host 3306

* refactor: test 패키지 구조 수정

인수테스트/통합테스트/단위테스트로 구분

* Revert "refactor: test 패키지 구조 수정"

This reverts commit 8fd90d362e53e6a459a34db0cbab5ca566ee2a24.

* refactor: 설정 파일 정리

(cherry picked from commit 9f0fea5da5b1d431891a6a092532a6bf336fb4ee)

* refactor: Answer패키지 Petition안으로 이동 및 조회 로직 개선 (#290)

* feat: 답변 생성 도메인 기능 구현

* feat: 답변 수정 도메인 기능 구현

* feat: 답변 삭제 도메인 기능 구현

UnAnsweredPetitionException.java -> NotAnsweredPetitionException.java

Un->Not으로 통일

* feat: Answer2 table 추가

* refactor: PetitionServiceTest 리팩터링

* feat: 답변 생성, 수정, 삭제 서비스 로직 구현

* refactor: 답변 CUD api 이동

* refactor: 답변 Read api 이동 및 dto 이동

* chore: ddl, flyway 설정 각 데이터베이스에서 진행하도록 이동.

변경이 거의 되지 않을 것이라 판단.

* refactor: AnswerServiceTest 로직 PetitionServiceTest로 이동

* refactor: AnswerService 삭제 및 PetitionDeleteEvent 삭제

* test: createAnswerWithConcurrency 삭제

지금의 테스트는 공개되지 않은 청원에 대해 답변을 달고 있고, 인수테스트에서 까지의 동시성 테스트를 진행하는 테스트 시간이 너무 큰 이유로 삭제

* refactor: Answer 삭제 및 Answer2->Answer

* refactor: Answered, Ongoing query 조회 로직 수정

* refactor: 조회 로직 개선

* refactor: default 0L을 전체 조회로 설정 하고, 구조 개선

* refactor: repository 패키지 분리

* refactor: 코드 정리

* chore: 권한 주석 처리 제거

* fix: categoryId = 0 부분 수정

기존 구조에서는 생성시 categoryId=0을 입력하게 되었을 때 null값으로 저장이 된다.

조회만을 위해 사용하는 로직이기 때문에 이는 별도로 분리하고자 했다.

또한 서비스 레이어에 로직이라기 보다는, 컨트롤러에서의 분기에 해당해야 한다고 생각한다.

parameter로 Category를 null로 넘기는 부분이 어색하다 판단했고, 코드의 중복이 있더라도 전체 조회와 카테고리 조회의 테스트를 분리하는게 더 자연스럽다 생각한다.

* refactor: 트랜잭션 제거 및 테스트만을 위한 메소드 삭제

* refactor: findPetitionOfUserId 로직 querydsl로 수정

* feat: agreeCount 테이블 생성 및 `@Version`도입. Petition-Answer 연관관계 주인 변경

* fix: 비관적 락을 통해 agreeCount 동시성 이슈 해결

* refactor: 도메인 nullable 처리 및 flyway 이력 분리

* test: 동시성 테스트 쓰레드 수 줄이기

비관적 락을 적용하게 되서 테스트 시간이 오래걸립니다. 조금이라도 줄이기 위해 줄여봅니다.

* feat: 답변된 청원 다시 답변시 예외 발생 로직 추가

* chore: 빠진 clear 추가 및 잘못된 sql 수정

(cherry picked from commit f2023c70fe1c6f3bb640344ec2437089b3bdbe17)

* refactor: 청원의 제목,내용에 길이 제한을 두기 위해 Embeddable class를 사용하도록 함. (#288)

* feat: Petition title, description이 invalid할 시의 exception 추가

* feat: Petition title, description 의embeddable class 추가

* refactor: Petition의 title, description 필드가 embedded 타입을 사용하도록 변경, setter메소드들을 삭제하고 petition update를 위한 도메인 메소드 추가.

* feat: title, description을 String 타입으로 받아오기 위한 getter 메소드 추가.

* fix: @Column 어노테이션 복구

* feat: invalid Title,Description으로 petition을 생성하는 실패테스트 추가.

* refactor: petition update 메소드 내부 구현 방식 수정 및 기타 작업

* refactor: 검증 메소드 분리

* test: petition create 테스트 이동 및 수정

Co-authored-by: wannte <T.wannte@gmail.com>
(cherry picked from commit 8ad216b073bcfa39272882807af3cdfbb5297724)

* refactor: 동의 시 AgreeCount 테이블에 잠금 설정으로 진행한다. (#295)

* chore: application-h2.yml flyway 설정 끄기

* refactor: AgreeCount 별도 분리

* feat: 비관적 잠금을 AgreeCount 테이블에만 잠그는 것으로 수정

* fix: inner join 하지 않아 count 조회시 발생하는 에러 수정

* chore: ManagerPermission 복원

* refactor: Keywork 조회 api 삭제

* chore: 필요없는 부분 삭제

(cherry picked from commit c4d872ed1523a07621a7026a364ad0ace8eb3c0f)

* fix: AgreeCount로 정렬 조회시 발생하는 문제 해결 및 테스트 추가 (#298)

우선은 급한 불을 끄는 느낌으로 진행했으나, 현재의 sorting방식은 petition의 모든 column에 대해 다 열어준 상황이고, 이 sorting 방식에 대해서도 열어줄 것을 정하고 별도로 정의해야 한다고 생각합니다.

PetitionQueryCondition과 비슷하게 PetitionQuerySorting 과 관련된 enum을 하나 정의해서 관리할 수 있을 것 같아요

(cherry picked from commit 2ee32875d2693a716bb9529bfabdc7e4fcd3344e)

* feat: 청원 조회 시 답변 정보도 함께 보내주도록 수정 (#296)

* chore: dataLoader 삭제 순서 변경

* chore: 사용하지 않는 메서드 삭제

* feat: Answer를 petition 정보와 함께 전달해준다.

* chore: 답변 생성 매니저 권한 지워진 부분 복원

(cherry picked from commit 5eae384733305fadfc3539eecbe8708b72892a0d)

* refactor: Answer content -> description 으로 수정 및 AnswerResponse 구체화 (#304)

* feat: PetitionResponse에 AnswerResponse정보 포함하도록 구현

* chore: agreements -> agreeCount

* chore: content -> description 통일

* refactor: content -> description column 명 수정

* chore: description 명칭 통일

* chore: 시간 수정 (#305)

* refactor: 지스트 청원 로고 사진 없이 구현 및 내용 수정 (#306)

* feat: userId를 공개하지 않는 방법으로 수정, username을 통해 로직 처리 (#311)

* refactor: 사용하지 않는 api 삭제

* refactor: updateUserRole username을 사용하도록 수정

* refactor: delete username을 사용하도록 수정

* refactor: userRole로 검색하는 기능 추가

* feat: userRole로 조회하는 기능 추가

* teat: userRole에 따른 테스트 추가

* chore: REQUIRED_AGREEMENT_FOR_ANSWER 50으로 수정

* refactor: userResponse id 칼럼 삭제

* refactor: 회원 가입 userId 노출 삭제

* refactor: signup statuscode ok to no-content

* feat: 테스트 환경 시 필요 동의 수 수정 (#318)

* feat: test 실행시 필요 동의 수 수정

* fix: 동의 수 50으로 수정되며 실패하는 dataloader 수정

* feat: 처리되지 않은 ExceptionHanlder에 대한 추가 및 정리 (#317)

* feat: 기본 resource mapping 끄기 및 handler가 존재하지 않은 때 NoHandlerFoundException 뱉도록 수정

* feat: NoHandlerFoundException 핸들러 추가

* feat: TypeMismatchException, HttpRequestMethodNotSupportedException 핸들러 추가

* feat: 낙관적 잠금에 대한 exceptionHandler 추가

이 부분은 AOP를 활용하여 진행할 수도 있지만, Petition을 수정하는 전체 범위에서 발생할 수 있는 문제이기 때문에 ControllerAdvice에 처리를 진행했다.

글로벌 ControllerAdvice가 아닌 Petition패키지에 ControllerAdvice를 두는 것도 고려해볼 만한 주제로 생각된다.

* chore: ApplicationException 로깅 제거

* feat: 승인/답변 대기중인 정보를 매니저에게 전달하는 스케쥴링을 구현한다. (#326)

* feat: 승인/답변 대기 중인 청원 알람 기능 구현

* feat: staff url 정보를 application.yml에서 넣어주는 것으로 수정

* test: 항상 낙관적 잠금 Exception을 보장할 수 없어 Exception으로 처리

실제 가끔 테스트가 터지는 형상 발생

* refactor: petition_scheduler.html에 css 추가. (#329)

* refactor: petition_scheduler.html에 css 추가.

* refactor: 글자 수정

* feature: youtube 링크를 답변에 추가한다. (#328)

* feat: Answer videoUrl column 추가

* refactor: Answer description 공유하도록 수정

* feat: VideoUrl youtube url 검증 로직 추가

domain 구조를 youtube가 아닌 다른 경우에도 확장가능하도록 진행.

물론 만약 종류가 여러개가 된다면 해당 패턴을 분기하여 적용하는 로직이 필요할듯.

* feat: ResponseDto에 videoUrl 추가

* chore: dataloader viedoUrl 탑재

* feat: ViedoUrl update 로직 구현

빈 칸이 입력되었을 때 ""

OCP 규칙을 위반. 만약 youtubue URL이 아니라면

* refactor: UrlMatcher를 OCP규칙을 지키도록 구현

URL패턴이 변경하더라도, UrlMatcher의 Bean만 다른 걸로 끼워주면 됩니다.

이 로직을 Service에서 먼저 진행해도 좋지만, VideoUrl의 도메인의 로직이라 생각해서 해당 Component를 직접 넘겨주는 방식으로 처리해봤습니다.

* chore: `manager@gist.ac.kr` 삭제 (#331)

* feat: 청원 반려 기능 구현 (#330)

* feat: petition 을 반려하는 도메인 구현

* feat: petition 반려 - 수정, 삭제 기능 구현

* feat: petition 반려 - 생성, 수정, 삭제 서비스 메서드 구현

* feat: petition 반려 - 조회 메서드 구현

* feat: petition dto 정보 수정

* chore: 고세연 사발면아

* chore: aws 제거

* chore: .jpb 제거

* feat: petition 반려 - cmd ctrl 구현

* refactor: petition 도메인 메서드 위치 변경

* feat: reject cmd ctrl method 매니저 인증 선언

* refactor: answer, rejection lazy loading 으로 수정

서비스 테스트 시 레이지 로딩으로 발생하는 문제 해결

Co-authored-by: wannte <T.wannte@gmail.com>

* fix: video url이 null인 경우 빈 스트링으로 수정 (#332)

현재 조회시 internal server error 발생

* fix: 승인/답변 대기중인 조회 컨디션 수정 (#340)

* fix: waiting for release/answer query condition 수정

* chore: dataloader data 갯수 수정

* fix: released petition 조회 조건 수정 (#344)

* fix: expired petition 조회 조건 수정 - not rejected 추가 (#348)

* fix: waiting for answer 매니저 권한 삭제 (#351)

* fix: 만료된 쿼리 조회시 notAnswered 조건 추가 (#357)

* feat: 답변을 요구하는 청원 동의 도달 시점의 timestamp를 보여주는 로직 구현 (#361)

* feat: 답변 대기중인 시간 추가

* feat: waitingForAnswerAt 조회되도록 반영

* chore: 동의 한 개 남은 청원 dataloader에 추가

Co-authored-by: grace_goose <choieungi@gm.gist.ac.kr>
Co-authored-by: koseyeon <koseyeon97@gmail.com>
Co-authored-by: koseyeon <82452337+koseyeon@users.noreply.github.com>
Co-authored-by: ChangHa Lee <60911416+GuruneLee@users.noreply.github.com>
Co-authored-by: gurunelee <dlckdgk4858@gmail.com>
Co-authored-by: netai <netai@netaiui-MacBookPro.local>