### PR TITLE
refactor: 청원이 Status를 enum으로 가지게끔 수정

### DIFF
--- a/src/main/java/com/gistpetition/api/DataLoader.java
+++ b/src/main/java/com/gistpetition/api/DataLoader.java
@@ -97,13 +97,11 @@ public class DataLoader {
             if (petitionId < petitionIds.get(0) + WAITING_FOR_CHECK_RELEASE_COUNT) {
                 continue;
             }
-            petitionCommandService.releasePetition(petitionId);
-
             if (petitionId < petitionIds.get(0) + WAITING_FOR_CHECK_RELEASE_COUNT + REJECTED_COUNT) {
                 petitionCommandService.rejectPetition(petitionId, REJECTION_REQUEST);
                 continue;
             }
-
+            petitionCommandService.releasePetition(petitionId);
             if (petitionId < petitionIds.get(0) + WAITING_FOR_CHECK_RELEASE_COUNT + REJECTED_COUNT + WAITING_FOR_CHECK_ANSWER_COUNT) {
                 continue;
             }

--- a/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToAnswerPetitionException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToAnswerPetitionException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class NotValidStatusToAnswerPetitionException extends PetitionException {
+    private static final String MESSAGE = "답변을 입력할 수 없는 상태의 청원입니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public NotValidStatusToAnswerPetitionException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToRejectPetitionException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToRejectPetitionException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class NotValidStatusToRejectPetitionException extends PetitionException {
+    private static final String MESSAGE = "반려할 수 없는 상태의 청원입니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public NotValidStatusToRejectPetitionException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToReleasePetitionException.java
+++ b/src/main/java/com/gistpetition/api/exception/petition/NotValidStatusToReleasePetitionException.java
@@ -1,0 +1,12 @@
+package com.gistpetition.api.exception.petition;
+
+import org.springframework.http.HttpStatus;
+
+public class NotValidStatusToReleasePetitionException extends PetitionException {
+    private static final String MESSAGE = "승인할 수 없는 상태의 청원입니다.";
+    private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+    public NotValidStatusToReleasePetitionException() {
+        super(MESSAGE, HTTP_STATUS);
+    }
+}

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionCommandService.java
@@ -23,8 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
-import static com.gistpetition.api.petition.domain.Petition.POSTING_PERIOD_BY_SECONDS;
-
 @Service
 @RequiredArgsConstructor
 public class PetitionCommandService {
@@ -38,15 +36,16 @@ public class PetitionCommandService {
 
     @Transactional
     public Long createPetition(PetitionRequest petitionRequest, Long userId) {
+        Petition petition = new Petition(
+                petitionRequest.getTitle(),
+                petitionRequest.getDescription(),
+                Category.of(petitionRequest.getCategoryId()),
+                userId);
         String tempUrl = urlGenerator.generate(TEMP_URL_LENGTH);
-        Petition created = petitionRepository.save(
-                new Petition(
-                        petitionRequest.getTitle(),
-                        petitionRequest.getDescription(),
-                        Category.of(petitionRequest.getCategoryId()),
-                        Instant.now().plusSeconds(POSTING_PERIOD_BY_SECONDS),
-                        userId,
-                        tempUrl));
+
+        petition.placeTemporary(tempUrl, Instant.now());
+
+        Petition created = petitionRepository.save(petition);
         agreeCountRepository.save(new AgreeCount(created.getId()));
         return created.getId();
     }

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryCondition.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryCondition.java
@@ -1,6 +1,7 @@
 package com.gistpetition.api.petition.application;
 
 import com.gistpetition.api.petition.domain.Petition;
+import com.gistpetition.api.petition.domain.Status;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -14,19 +15,14 @@ import static com.gistpetition.api.petition.domain.QAgreeCount.agreeCount;
 import static com.gistpetition.api.petition.domain.QPetition.petition;
 
 public enum PetitionQueryCondition {
-    RELEASED(none, released),
-    NOT_RELEASED(none, notReleased),
-    ANSWERED(none, answered),
-    NOT_ANSWERED(none, notAnswered),
+    NOT_TEMPORARY(none, non_temporary),
 
-    WAITING_FOR_RELEASE(notExpired, notReleased, notRejected, agreeEnoughToRelease),
-    ONGOING(notExpired, released, notAnswered, notRejected),
-    REJECTED(none, released, rejected),
-    RELEASED_NOT_REJECTED_NOT_ANSWERED_EXPIRED(expired, released, notAnswered, notRejected),
-    WAITING_FOR_ANSWER(none, released, notRejected, notAnswered, agreeEnoughToAnswer),
-
-    RELEASED_NOT_EXPIRED(notExpired, released),
-    RELEASED_EXPIRED(expired, released);
+    WAITING_FOR_RELEASE(notExpired, non_temporary, agreeEnoughToRelease),
+    ONGOING(notExpired, released),
+    EXPIRED(expired, released),
+    REJECTED(none, rejected),
+    WAITING_FOR_ANSWER(none, released, agreeEnoughToAnswer),
+    ANSWERED(none, answered);
 
     private final ExpirationCondition expirationCondition;
     private final PetitionStatus[] conditions;
@@ -62,12 +58,11 @@ public enum PetitionQueryCondition {
     }
 
     enum PetitionStatus {
-        released(petition.released.isTrue()),
-        notReleased(petition.released.isFalse()),
-        rejected(petition.rejection.isNotNull()),
-        notRejected(petition.rejection.isNull()),
-        answered(petition.answer.isNotNull()),
-        notAnswered(petition.answer.isNull()),
+        temporary(petition.status.eq(Status.TEMPORARY)),
+        non_temporary(petition.status.ne(Status.TEMPORARY)),
+        released(petition.status.eq(Status.RELEASED)),
+        rejected(petition.status.eq(Status.REJECTED)),
+        answered(petition.status.eq(Status.ANSWERED)),
         agreeEnoughToRelease(agreeCount.count.goe(Petition.REQUIRED_AGREEMENT_FOR_RELEASE)),
         agreeEnoughToAnswer(agreeCount.count.goe(Petition.REQUIRED_AGREEMENT_FOR_ANSWER));
 

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryDslDao.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryDslDao.java
@@ -1,7 +1,8 @@
-package com.gistpetition.api.petition.domain.repository;
+package com.gistpetition.api.petition.application;
 
 import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.Petition;
+import com.gistpetition.api.petition.domain.Status;
 import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
 import com.gistpetition.api.petition.dto.QPetitionPreviewResponse;
 import com.querydsl.core.types.Order;
@@ -25,7 +26,7 @@ import static com.gistpetition.api.petition.domain.QPetition.petition;
 
 @Repository
 @RequiredArgsConstructor
-public class PetitionQueryDslRepository {
+public class PetitionQueryDslDao {
     private final JPQLQueryFactory jpqlQueryFactory;
 
     public List<PetitionPreviewResponse> findAll(Category category, Predicate predicate) {
@@ -65,7 +66,7 @@ public class PetitionQueryDslRepository {
     }
 
     private QPetitionPreviewResponse buildPetitionPreviewResponse() {
-        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.status, petition.createdAt, petition.expiredAt, petition.waitingForAnswerAt, agreeCount.count, petition.tempUrl, petition.released, petition.rejection.isNotNull(), petition.answer.isNotNull());
+        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.status, petition.createdAt, petition.expiredAt, petition.waitingForAnswerAt, agreeCount.count, petition.tempUrl, petition.status.ne(Status.TEMPORARY), petition.status.eq(Status.REJECTED), petition.status.eq(Status.ANSWERED));
     }
 
     private BooleanExpression categoryEq(Category category) {

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
@@ -8,7 +8,6 @@ import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.Petition;
 import com.gistpetition.api.petition.domain.repository.AgreementRepository;
 import com.gistpetition.api.petition.domain.repository.AnswerRepository;
-import com.gistpetition.api.petition.domain.repository.PetitionQueryDslRepository;
 import com.gistpetition.api.petition.domain.repository.PetitionRepository;
 import com.gistpetition.api.petition.dto.*;
 import com.gistpetition.api.user.domain.User;
@@ -32,99 +31,6 @@ public class PetitionQueryService {
     private final AnswerRepository answerRepository;
     private final AgreementRepository agreementRepository;
     private final UserRepository userRepository;
-    private final PetitionQueryDslRepository petitionQueryDslRepository;
-
-    public Page<PetitionPreviewResponse> retrieveNotTemporaryPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, NOT_TEMPORARY.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveNotTemporaryPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, NOT_TEMPORARY.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, EXPIRED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, EXPIRED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveOngoingPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, ONGOING.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveOngoingPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, ONGOING.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveWaitingForReleasePetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveWaitingForReleasePetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, WAITING_FOR_RELEASE.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveWaitingForAnswerPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveWaitingForAnswerPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, WAITING_FOR_ANSWER.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveRejectedPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, REJECTED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveRejectedPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, REJECTED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveAnsweredPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, ANSWERED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrieveAnsweredPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, ANSWERED.at(Instant.now()), pageable);
-    }
-
-    public Page<PetitionPreviewResponse> retrievePetitionsByUserId(Long userId, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, petition.userId.eq(userId), pageable);
-    }
-
-    public Long retrieveReleasedPetitionCount() {
-        return petitionQueryDslRepository.count(null, NOT_TEMPORARY.at(Instant.now()));
-    }
-
-    public Long retrieveReleasedPetitionCount(Category category) {
-        return petitionQueryDslRepository.count(category, NOT_TEMPORARY.at(Instant.now()));
-    }
-
-    public Long retrieveWaitingForReleasePetitionCount() {
-        return petitionQueryDslRepository.count(null, WAITING_FOR_RELEASE.at(Instant.now()));
-    }
-
-    public Long retrieveWaitingForReleasePetitionCount(Category category) {
-        return petitionQueryDslRepository.count(category, WAITING_FOR_RELEASE.at(Instant.now()));
-    }
-
-    public Long retrieveWaitingForAnswerPetitionCount() {
-        return petitionQueryDslRepository.count(null, WAITING_FOR_ANSWER.at(Instant.now()));
-    }
-
-    public Long retrieveWaitingForAnswerPetitionCount(Category category) {
-        return petitionQueryDslRepository.count(category, WAITING_FOR_ANSWER.at(Instant.now()));
-    }
-
-    public Long retrieveAnsweredPetitionCount() {
-        return petitionQueryDslRepository.count(null, ANSWERED.at(Instant.now()));
-    }
-
-    public Long retrieveAnsweredPetitionCount(Category category) {
-        return petitionQueryDslRepository.count(category, ANSWERED.at(Instant.now()));
-    }
 
     @Transactional(readOnly = true)
     public PetitionResponse retrieveReleasedPetitionById(Long petitionId) {

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
@@ -34,20 +34,20 @@ public class PetitionQueryService {
     private final UserRepository userRepository;
     private final PetitionQueryDslRepository petitionQueryDslRepository;
 
-    public Page<PetitionPreviewResponse> retrieveReleasedPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, RELEASED.at(Instant.now()), pageable);
+    public Page<PetitionPreviewResponse> retrieveNotTemporaryPetition(Pageable pageable) {
+        return petitionQueryDslRepository.findAll(null, NOT_TEMPORARY.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrieveReleasedPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, RELEASED.at(Instant.now()), pageable);
+    public Page<PetitionPreviewResponse> retrieveNotTemporaryPetition(Category category, Pageable pageable) {
+        return petitionQueryDslRepository.findAll(category, NOT_TEMPORARY.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Pageable pageable) {
-        return petitionQueryDslRepository.findAll(null, RELEASED_NOT_REJECTED_NOT_ANSWERED_EXPIRED.at(Instant.now()), pageable);
+    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Pageable pageable) {
+        return petitionQueryDslRepository.findAll(null, EXPIRED.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrieveReleasedAndExpiredPetition(Category category, Pageable pageable) {
-        return petitionQueryDslRepository.findAll(category, RELEASED_NOT_REJECTED_NOT_ANSWERED_EXPIRED.at(Instant.now()), pageable);
+    public Page<PetitionPreviewResponse> retrieveExpiredPetition(Category category, Pageable pageable) {
+        return petitionQueryDslRepository.findAll(category, EXPIRED.at(Instant.now()), pageable);
     }
 
     public Page<PetitionPreviewResponse> retrieveOngoingPetition(Pageable pageable) {
@@ -58,19 +58,19 @@ public class PetitionQueryService {
         return petitionQueryDslRepository.findAll(category, ONGOING.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrievePetitionsWaitingForRelease(Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveWaitingForReleasePetition(Pageable pageable) {
         return petitionQueryDslRepository.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrievePetitionsWaitingForRelease(Category category, Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveWaitingForReleasePetition(Category category, Pageable pageable) {
         return petitionQueryDslRepository.findAll(category, WAITING_FOR_RELEASE.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrievePetitionsWaitingForAnswer(Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveWaitingForAnswerPetition(Pageable pageable) {
         return petitionQueryDslRepository.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()), pageable);
     }
 
-    public Page<PetitionPreviewResponse> retrievePetitionsWaitingForAnswer(Category category, Pageable pageable) {
+    public Page<PetitionPreviewResponse> retrieveWaitingForAnswerPetition(Category category, Pageable pageable) {
         return petitionQueryDslRepository.findAll(category, WAITING_FOR_ANSWER.at(Instant.now()), pageable);
     }
 
@@ -95,11 +95,11 @@ public class PetitionQueryService {
     }
 
     public Long retrieveReleasedPetitionCount() {
-        return petitionQueryDslRepository.count(null, RELEASED.at(Instant.now()));
+        return petitionQueryDslRepository.count(null, NOT_TEMPORARY.at(Instant.now()));
     }
 
     public Long retrieveReleasedPetitionCount(Category category) {
-        return petitionQueryDslRepository.count(category, RELEASED.at(Instant.now()));
+        return petitionQueryDslRepository.count(category, NOT_TEMPORARY.at(Instant.now()));
     }
 
     public Long retrieveWaitingForReleasePetitionCount() {

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
@@ -129,7 +129,7 @@ public class PetitionQueryService {
     @Transactional(readOnly = true)
     public PetitionResponse retrieveReleasedPetitionById(Long petitionId) {
         Petition petition = findPetitionById(petitionId);
-        if (!petition.isReleased()) {
+        if (petition.isTemporary()) {
             throw new NotReleasedPetitionException();
         }
         return PetitionResponse.of(petition);

--- a/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
+++ b/src/main/java/com/gistpetition/api/petition/application/PetitionQueryService.java
@@ -4,7 +4,6 @@ import com.gistpetition.api.exception.petition.NoSuchPetitionException;
 import com.gistpetition.api.exception.petition.NotReleasedPetitionException;
 import com.gistpetition.api.exception.user.NoSuchUserException;
 import com.gistpetition.api.petition.domain.Agreement;
-import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.Petition;
 import com.gistpetition.api.petition.domain.repository.AgreementRepository;
 import com.gistpetition.api.petition.domain.repository.AnswerRepository;
@@ -18,11 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-
-import static com.gistpetition.api.petition.application.PetitionQueryCondition.*;
-import static com.gistpetition.api.petition.domain.QPetition.petition;
-
 @Service
 @RequiredArgsConstructor
 public class PetitionQueryService {
@@ -33,7 +27,7 @@ public class PetitionQueryService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public PetitionResponse retrieveReleasedPetitionById(Long petitionId) {
+    public PetitionResponse retrieveNotTemporaryPetitionById(Long petitionId) {
         Petition petition = findPetitionById(petitionId);
         if (petition.isTemporary()) {
             throw new NotReleasedPetitionException();

--- a/src/main/java/com/gistpetition/api/petition/domain/Category.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Category.java
@@ -29,10 +29,6 @@ public enum Category {
         return id;
     }
 
-    public String getName() {
-        return name;
-    }
-
     public static Category of(Long categoryId) {
         if (!lookup.containsKey(categoryId)) {
             throw new NoSuchCategoryException();

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -106,7 +106,6 @@ public class Petition extends BaseEntity {
         if (agreements.agreeLessThan(REQUIRED_AGREEMENT_FOR_RELEASE)) {
             throw new NotEnoughAgreementException();
         }
-        this.released = true;
         this.status = RELEASED;
     }
 
@@ -114,7 +113,6 @@ public class Petition extends BaseEntity {
         if (!isReleased()) {
             throw new NotReleasedPetitionException();
         }
-        this.released = false;
         this.status = TEMPORARY;
     }
 
@@ -124,9 +122,6 @@ public class Petition extends BaseEntity {
         }
         if (!isTemporary()) {
             throw new NotValidStatusToRejectPetitionException();
-        }
-        if (!released) {
-            release(at);
         }
         this.rejection = new Rejection(description, this);
         this.status = REJECTED;

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -63,15 +63,6 @@ public class Petition extends BaseEntity {
         this.userId = userId;
     }
 
-    public Petition(String title, String description, Category category, Instant expiredAt, Long userId, String tempUrl) {
-        this.title = new Title(title);
-        this.description = new Description(description);
-        this.category = category;
-        this.expiredAt = expiredAt;
-        this.userId = userId;
-        this.tempUrl = tempUrl;
-    }
-
     public void placeTemporary(String tempUrl, Instant at) {
         this.status = TEMPORARY;
         this.tempUrl = tempUrl;
@@ -100,8 +91,8 @@ public class Petition extends BaseEntity {
         if (isExpiredAt(at)) {
             throw new ExpiredPetitionException();
         }
-        if (isReleased()) {
-            throw new AlreadyReleasedPetitionException();
+        if (!isTemporary()) {
+            throw new NotValidStatusToReleasePetitionException();
         }
         if (agreements.agreeLessThan(REQUIRED_AGREEMENT_FOR_RELEASE)) {
             throw new NotEnoughAgreementException();

--- a/src/main/java/com/gistpetition/api/petition/domain/Petition.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Petition.java
@@ -13,6 +13,8 @@ import javax.persistence.*;
 import java.time.Instant;
 import java.util.Objects;
 
+import static com.gistpetition.api.petition.domain.Status.TEMPORARY;
+
 @Audited
 @Getter
 @Entity
@@ -27,6 +29,8 @@ public class Petition extends BaseEntity {
     private Description description;
     @Enumerated(EnumType.STRING)
     private Category category;
+    @NotAudited
+    private Status status;
     @NotAudited
     private Boolean released = false;
     @NotAudited
@@ -52,6 +56,10 @@ public class Petition extends BaseEntity {
     protected Petition() {
     }
 
+    public Petition(String title, String description, Category category, Long userId) {
+        this(title, description, category, null, userId, null);
+    }
+
     public Petition(String title, String description, Category category, Instant expiredAt, Long userId, String tempUrl) {
         this.title = new Title(title);
         this.description = new Description(description);
@@ -59,6 +67,12 @@ public class Petition extends BaseEntity {
         this.expiredAt = expiredAt;
         this.userId = userId;
         this.tempUrl = tempUrl;
+    }
+
+    public void placeTemporary(String tempUrl, Instant at) {
+        this.status = TEMPORARY;
+        this.tempUrl = tempUrl;
+        this.expiredAt = at.plusSeconds(POSTING_PERIOD_BY_SECONDS);
     }
 
     public void agree(Long userId, String description, Instant at) {

--- a/src/main/java/com/gistpetition/api/petition/domain/Status.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Status.java
@@ -4,6 +4,5 @@ public enum Status {
     TEMPORARY,
     RELEASED,
     REJECTED,
-    ANSWERED,
-    EXPIRED
+    ANSWERED
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/Status.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/Status.java
@@ -1,0 +1,9 @@
+package com.gistpetition.api.petition.domain;
+
+public enum Status {
+    TEMPORARY,
+    RELEASED,
+    REJECTED,
+    ANSWERED,
+    EXPIRED
+}

--- a/src/main/java/com/gistpetition/api/petition/domain/repository/AgreeCountRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/repository/AgreeCountRepository.java
@@ -16,6 +16,6 @@ public interface AgreeCountRepository extends JpaRepository<AgreeCount, Long> {
     Optional<AgreeCount> findByPetitionId(Long petitionId);
 
     @Modifying
-    @Query("update AgreeCount a  set a.count = a.count + 1 where a.petitionId = ?1")
+    @Query("update AgreeCount a set a.count = a.count + 1 where a.petitionId = ?1")
     void incrementCount(Long petitionId);
 }

--- a/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
+++ b/src/main/java/com/gistpetition/api/petition/domain/repository/PetitionQueryDslRepository.java
@@ -65,7 +65,7 @@ public class PetitionQueryDslRepository {
     }
 
     private QPetitionPreviewResponse buildPetitionPreviewResponse() {
-        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.createdAt, petition.expiredAt, petition.waitingForAnswerAt, agreeCount.count, petition.tempUrl, petition.released, petition.rejection.isNotNull(), petition.answer.isNotNull());
+        return new QPetitionPreviewResponse(petition.id, petition.title.title, petition.category, petition.status, petition.createdAt, petition.expiredAt, petition.waitingForAnswerAt, agreeCount.count, petition.tempUrl, petition.released, petition.rejection.isNotNull(), petition.answer.isNotNull());
     }
 
     private BooleanExpression categoryEq(Category category) {

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -28,7 +28,7 @@ public class PetitionPreviewResponse {
     public PetitionPreviewResponse(Long id, String title, Category category, Status status, Instant createdAt, Instant expiredAt, Instant waitingForAnswerAt, Integer agreeCount, String tempUrl, Boolean released, Boolean rejected, Boolean answered) {
         this.id = id;
         this.title = title;
-        this.categoryName = category.getName();
+        this.categoryName = category.name();
         this.status = status.name();
         this.createdAt = createdAt.toEpochMilli();
         this.waitingForAnswerAt = waitingForAnswerAt != null ? waitingForAnswerAt.toEpochMilli() : null;

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionPreviewResponse.java
@@ -1,6 +1,7 @@
 package com.gistpetition.api.petition.dto;
 
 import com.gistpetition.api.petition.domain.Category;
+import com.gistpetition.api.petition.domain.Status;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ public class PetitionPreviewResponse {
     private Long id;
     private String title;
     private String categoryName;
+    private String status;
     private Integer agreeCount;
     private Long createdAt;
     private Long waitingForAnswerAt;
@@ -23,10 +25,11 @@ public class PetitionPreviewResponse {
     private Boolean expired;
 
     @QueryProjection
-    public PetitionPreviewResponse(Long id, String title, Category category, Instant createdAt, Instant expiredAt, Instant waitingForAnswerAt, Integer agreeCount, String tempUrl, Boolean released, Boolean rejected, Boolean answered) {
+    public PetitionPreviewResponse(Long id, String title, Category category, Status status, Instant createdAt, Instant expiredAt, Instant waitingForAnswerAt, Integer agreeCount, String tempUrl, Boolean released, Boolean rejected, Boolean answered) {
         this.id = id;
         this.title = title;
         this.categoryName = category.getName();
+        this.status = status.name();
         this.createdAt = createdAt.toEpochMilli();
         this.waitingForAnswerAt = waitingForAnswerAt != null ? waitingForAnswerAt.toEpochMilli() : null;
         this.agreeCount = agreeCount;

--- a/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
+++ b/src/main/java/com/gistpetition/api/petition/dto/PetitionResponse.java
@@ -17,6 +17,7 @@ public class PetitionResponse {
     private String title;
     private String description;
     private String categoryName;
+    private String status;
     private Integer agreeCount;
     private Long createdAt;
     private Long updatedAt;
@@ -37,13 +38,14 @@ public class PetitionResponse {
                 petition.getId(),
                 petition.getTitle(),
                 petition.getDescription(),
-                petition.getCategory().getName(),
+                petition.getCategory().name(),
+                petition.getStatus().name(),
                 petition.getAgreeCount(),
                 petition.getCreatedAt().toEpochMilli(),
                 petition.getUpdatedAt().toEpochMilli(),
                 waitingForAnswerAt != null ? waitingForAnswerAt.toEpochMilli() : null,
                 petition.getTempUrl(),
-                petition.isReleased(),
+                !petition.isTemporary(),
                 petition.isRejected(),
                 petition.isAnswered(),
                 petition.isExpiredAt(Instant.now()),

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
@@ -3,6 +3,7 @@ package com.gistpetition.api.petition.presentation;
 import com.gistpetition.api.config.annotation.LoginRequired;
 import com.gistpetition.api.config.annotation.LoginUser;
 import com.gistpetition.api.config.annotation.ManagerPermissionRequired;
+import com.gistpetition.api.petition.application.PetitionQueryDslDao;
 import com.gistpetition.api.petition.application.PetitionQueryService;
 import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.dto.*;
@@ -13,102 +14,108 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
+
+import static com.gistpetition.api.petition.application.PetitionQueryCondition.*;
+import static com.gistpetition.api.petition.domain.QPetition.petition;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 public class PetitionQueryController {
     private static final String SEARCH_ALL = "0";
     private final PetitionQueryService petitionQueryService;
+    private final PetitionQueryDslDao petitionQueryDslDao;
 
     @GetMapping("/petitions")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveNotTemporaryPetition(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveNotTemporaryPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, NOT_TEMPORARY.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveNotTemporaryPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), NOT_TEMPORARY.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/ongoing")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveOngoingPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveOngoingPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, ONGOING.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveOngoingPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), ONGOING.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/expired")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedAndExpiredPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveExpiredPetition(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveExpiredPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, EXPIRED.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveExpiredPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), EXPIRED.at(Instant.now()), pageable));
     }
 
     @ManagerPermissionRequired
     @GetMapping("/petitions/waitingForRelease")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForRelease(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), WAITING_FOR_RELEASE.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/waitingForAnswer")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForAnswer(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), WAITING_FOR_ANSWER.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/rejected")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveRejectedPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveRejectedPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, REJECTED.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveRejectedPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), REJECTED.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/answered")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveAnsweredPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveAnsweredPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, ANSWERED.at(Instant.now()), pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveAnsweredPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(Category.of(categoryId), ANSWERED.at(Instant.now()), pageable));
     }
 
     @GetMapping("/petitions/count")
-    public ResponseEntity<Long> retrieveReleasedPetitionCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
+    public ResponseEntity<Long> retrieveNotTemporaryPetitionCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedPetitionCount());
+            return ResponseEntity.ok().body(petitionQueryDslDao.count(null, NOT_TEMPORARY.at(Instant.now())));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedPetitionCount(Category.of(categoryId)));
+        return ResponseEntity.ok().body(petitionQueryDslDao.count(Category.of(categoryId), NOT_TEMPORARY.at(Instant.now())));
     }
 
     @ManagerPermissionRequired
     @GetMapping("/petitions/waitingForRelease/count")
-    public ResponseEntity<Long> retrievePetitionsWaitingForCheckCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
+    public ResponseEntity<Long> retrieveWaitingForReleasePetitionCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetitionCount());
+            return ResponseEntity.ok().body(petitionQueryDslDao.count(null, WAITING_FOR_RELEASE.at(Instant.now())));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetitionCount(Category.of(categoryId)));
+        return ResponseEntity.ok().body(petitionQueryDslDao.count(Category.of(categoryId), WAITING_FOR_RELEASE.at(Instant.now())));
     }
 
     @ManagerPermissionRequired
     @GetMapping("/petitions/waitingForAnswer/count")
-    public ResponseEntity<Long> retrievePetitionsWaitingForAnswerCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
+    public ResponseEntity<Long> retrieveWaitingForAnswerPetitionCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetitionCount());
+            return ResponseEntity.ok().body(petitionQueryDslDao.count(null, WAITING_FOR_ANSWER.at(Instant.now())));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetitionCount(Category.of(categoryId)));
+        return ResponseEntity.ok().body(petitionQueryDslDao.count(Category.of(categoryId), WAITING_FOR_ANSWER.at(Instant.now())));
     }
 
     @GetMapping("/petitions/answered/count")
     public ResponseEntity<Long> retrieveAnsweredPetitionCount(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveAnsweredPetitionCount());
+            return ResponseEntity.ok().body(petitionQueryDslDao.count(null, ANSWERED.at(Instant.now())));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveAnsweredPetitionCount(Category.of(categoryId)));
+        return ResponseEntity.ok().body(petitionQueryDslDao.count(Category.of(categoryId), ANSWERED.at(Instant.now())));
     }
 
     @GetMapping("/petitions/{petitionId}")
@@ -124,7 +131,7 @@ public class PetitionQueryController {
     @LoginRequired
     @GetMapping("/petitions/me")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsOfMine(@LoginUser SimpleUser simpleUser, Pageable pageable) {
-        return ResponseEntity.ok().body(petitionQueryService.retrievePetitionsByUserId(simpleUser.getId(), pageable));
+        return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, petition.userId.eq(simpleUser.getId()), pageable));
     }
 
     @ManagerPermissionRequired

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
@@ -23,9 +23,9 @@ public class PetitionQueryController {
     @GetMapping("/petitions")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryService.retrieveNotTemporaryPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryService.retrieveNotTemporaryPetition(Category.of(categoryId), pageable));
     }
 
     @GetMapping("/petitions/ongoing")
@@ -39,26 +39,26 @@ public class PetitionQueryController {
     @GetMapping("/petitions/expired")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrieveReleasedAndExpiredPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedAndExpiredPetition(pageable));
+            return ResponseEntity.ok().body(petitionQueryService.retrieveExpiredPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedAndExpiredPetition(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryService.retrieveExpiredPetition(Category.of(categoryId), pageable));
     }
 
     @ManagerPermissionRequired
     @GetMapping("/petitions/waitingForRelease")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForRelease(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrievePetitionsWaitingForRelease(pageable));
+            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrievePetitionsWaitingForRelease(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForReleasePetition(Category.of(categoryId), pageable));
     }
 
     @GetMapping("/petitions/waitingForAnswer")
     public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForAnswer(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
-            return ResponseEntity.ok().body(petitionQueryService.retrievePetitionsWaitingForAnswer(pageable));
+            return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetition(pageable));
         }
-        return ResponseEntity.ok().body(petitionQueryService.retrievePetitionsWaitingForAnswer(Category.of(categoryId), pageable));
+        return ResponseEntity.ok().body(petitionQueryService.retrieveWaitingForAnswerPetition(Category.of(categoryId), pageable));
     }
 
     @GetMapping("/petitions/rejected")

--- a/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
+++ b/src/main/java/com/gistpetition/api/petition/presentation/PetitionQueryController.java
@@ -28,7 +28,7 @@ public class PetitionQueryController {
     private final PetitionQueryDslDao petitionQueryDslDao;
 
     @GetMapping("/petitions")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveNotTemporaryPetition(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveNotTemporaryPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
             return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, NOT_TEMPORARY.at(Instant.now()), pageable));
         }
@@ -44,7 +44,7 @@ public class PetitionQueryController {
     }
 
     @GetMapping("/petitions/expired")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveExpiredPetition(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveExpiredPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
             return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, EXPIRED.at(Instant.now()), pageable));
         }
@@ -53,7 +53,7 @@ public class PetitionQueryController {
 
     @ManagerPermissionRequired
     @GetMapping("/petitions/waitingForRelease")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForRelease(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveWaitingForReleasePetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
             return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()), pageable));
         }
@@ -61,7 +61,7 @@ public class PetitionQueryController {
     }
 
     @GetMapping("/petitions/waitingForAnswer")
-    public ResponseEntity<Page<PetitionPreviewResponse>> retrievePetitionsWaitingForAnswer(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
+    public ResponseEntity<Page<PetitionPreviewResponse>> retrieveWaitingForAnswerPetitions(@RequestParam(defaultValue = SEARCH_ALL) Long categoryId, Pageable pageable) {
         if (categoryId.equals(Long.valueOf(SEARCH_ALL))) {
             return ResponseEntity.ok().body(petitionQueryDslDao.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()), pageable));
         }
@@ -119,8 +119,8 @@ public class PetitionQueryController {
     }
 
     @GetMapping("/petitions/{petitionId}")
-    public ResponseEntity<PetitionResponse> retrieveReleasedPetition(@PathVariable Long petitionId) {
-        return ResponseEntity.ok().body(petitionQueryService.retrieveReleasedPetitionById(petitionId));
+    public ResponseEntity<PetitionResponse> retrieveNotTemporaryPetition(@PathVariable Long petitionId) {
+        return ResponseEntity.ok().body(petitionQueryService.retrieveNotTemporaryPetitionById(petitionId));
     }
 
     @GetMapping("/petitions/temp/{tempUrl}")

--- a/src/main/java/com/gistpetition/api/scheduler/PetitionScheduler.java
+++ b/src/main/java/com/gistpetition/api/scheduler/PetitionScheduler.java
@@ -1,6 +1,6 @@
 package com.gistpetition.api.scheduler;
 
-import com.gistpetition.api.petition.domain.repository.PetitionQueryDslRepository;
+import com.gistpetition.api.petition.application.PetitionQueryDslDao;
 import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
 import com.gistpetition.api.user.domain.User;
 import com.gistpetition.api.user.domain.UserRepository;
@@ -30,15 +30,15 @@ public class PetitionScheduler {
     @Value("${staff.url:https://staff.gist-petition.com}")
     private String staffUrl;
     private final UserRepository userRepository;
-    private final PetitionQueryDslRepository petitionQueryDslRepository;
+    private final PetitionQueryDslDao petitionQueryDslDao;
     private final SpringTemplateEngine springTemplateEngine;
     private final EmailSender emailSender;
 
     @Scheduled(cron = "0 0 9 * * MON-FRI", zone = "Asia/Seoul")
     public void schedule() {
         List<User> managers = userRepository.findAllByUserRole(UserRole.MANAGER);
-        List<PetitionPreviewResponse> waitingForRelease = petitionQueryDslRepository.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()));
-        List<PetitionPreviewResponse> waitingForAnswer = petitionQueryDslRepository.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()));
+        List<PetitionPreviewResponse> waitingForRelease = petitionQueryDslDao.findAll(null, WAITING_FOR_RELEASE.at(Instant.now()));
+        List<PetitionPreviewResponse> waitingForAnswer = petitionQueryDslDao.findAll(null, WAITING_FOR_ANSWER.at(Instant.now()));
 
         List<String> usernames = managers.stream().map(User::getUsername).collect(Collectors.toList());
         String subject = String.format("[지스트 청원] 오늘의 승인 대기 중인 청원: %d, 답변 대기 중인 청원: %d", waitingForRelease.size(), waitingForAnswer.size());

--- a/src/main/resources/db/migration/V1_12__add_petition_status.sql
+++ b/src/main/resources/db/migration/V1_12__add_petition_status.sql
@@ -1,0 +1,14 @@
+ALTER TABLE petition
+    ADD status VARCHAR(255) NULL DEFAULT 'TEMPORARY';
+
+UPDATE petition
+SET status = 'RELEASED'
+WHERE released = 1;
+
+UPDATE petition
+SET status = 'REJECTED'
+WHERE rejection_id IS NOT NULL;
+
+UPDATE petition
+SET status = 'ANSWERED'
+WHERE answer_id IS NOT NULL;

--- a/src/test/java/com/gistpetition/api/petition/PetitionBuilder.java
+++ b/src/test/java/com/gistpetition/api/petition/PetitionBuilder.java
@@ -3,27 +3,17 @@ package com.gistpetition.api.petition;
 import com.gistpetition.api.petition.domain.Category;
 import com.gistpetition.api.petition.domain.Petition;
 
-import java.time.Instant;
-
 public final class PetitionBuilder {
-    private Boolean answered = false;
     private String title = "제목";
     private String description = "내용";
     private Category category = Category.DORMITORY;
-    private Instant expiredAt = Instant.now().plusSeconds(Petition.POSTING_PERIOD_BY_SECONDS);
     private Long userId;
-    private String tempUrl;
 
     private PetitionBuilder() {
     }
 
     public static PetitionBuilder aPetition() {
         return new PetitionBuilder();
-    }
-
-    public PetitionBuilder withAnswered(Boolean answered) {
-        this.answered = answered;
-        return this;
     }
 
     public PetitionBuilder withTitle(String title) {
@@ -41,22 +31,12 @@ public final class PetitionBuilder {
         return this;
     }
 
-    public PetitionBuilder withExpiredAt(Instant expiredAt) {
-        this.expiredAt = expiredAt;
-        return this;
-    }
-
     public PetitionBuilder withUserId(Long userId) {
         this.userId = userId;
         return this;
     }
 
-    public PetitionBuilder withTempUrl(String tempUrl) {
-        this.tempUrl = tempUrl;
-        return this;
-    }
-
     public Petition build() {
-        return new Petition(title, description, category, expiredAt, userId, tempUrl);
+        return new Petition(title, description, category, userId);
     }
 }

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionQueryDslDaoTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionQueryDslDaoTest.java
@@ -1,0 +1,133 @@
+package com.gistpetition.api.petition.application;
+
+import com.gistpetition.api.IntegrationTest;
+import com.gistpetition.api.petition.domain.Category;
+import com.gistpetition.api.petition.dto.AgreementRequest;
+import com.gistpetition.api.petition.dto.AnswerRequest;
+import com.gistpetition.api.petition.dto.PetitionPreviewResponse;
+import com.gistpetition.api.petition.dto.PetitionRequest;
+import com.gistpetition.api.user.domain.User;
+import com.gistpetition.api.user.domain.UserRepository;
+import com.gistpetition.api.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static com.gistpetition.api.petition.application.PetitionQueryCondition.ANSWERED;
+import static com.gistpetition.api.petition.application.PetitionQueryCondition.ONGOING;
+import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_ANSWER;
+import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_RELEASE;
+import static com.gistpetition.api.petition.domain.QPetition.petition;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PetitionQueryDslDaoTest extends IntegrationTest {
+    private static final AgreementRequest AGREEMENT_REQUEST = new AgreementRequest("동의합니다.");
+    private static final AnswerRequest ANSWER_REQUEST = new AnswerRequest("답변을 달았다");
+    private static final PetitionRequest DORM_PETITION_REQUEST = new PetitionRequest("title", "description", Category.DORMITORY.getId());
+    public static final String EMAIL = "email@gist.ac.kr";
+    public static final String PASSWORD = "password";
+
+    @Autowired
+    private PetitionQueryDslDao petitionQueryDslDao;
+    @Autowired
+    private PetitionCommandService petitionCommandService;
+    @Autowired
+    private UserRepository userRepository;
+
+    private User petitionOwner;
+
+    @BeforeEach
+    void setUp() {
+        petitionOwner = userRepository.save(new User(EMAIL, PASSWORD, UserRole.USER));
+    }
+
+    @Test
+    void retrieveOngoingPetition() {
+        int numOfPetition = 3;
+        List<Long> createdPetitionIds = new ArrayList<>();
+        for (int i = 0; i < numOfPetition; i++) {
+            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
+        }
+        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
+        createdPetitionIds.forEach(i -> {
+            agreePetitionBy(i, users);
+            petitionCommandService.releasePetition(i);
+        });
+
+        Page<PetitionPreviewResponse> petitions = petitionQueryDslDao.findAll(null, ONGOING.at(Instant.now()), PageRequest.of(0, 10));
+        assertThat(petitions.getContent()).hasSize(numOfPetition);
+    }
+
+    @Test
+    void retrieveOngoingPetitionWithAgreeCountSort() {
+        int numOfPetition = 3;
+        List<Long> createdPetitionIds = new ArrayList<>();
+        for (int i = 0; i < numOfPetition; i++) {
+            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
+        }
+        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
+        createdPetitionIds.forEach(i -> {
+            agreePetitionBy(i, users);
+            petitionCommandService.releasePetition(i);
+        });
+
+        User user1 = userRepository.save(new User("new@gist.ac.kr", "password", UserRole.USER));
+        User user2 = userRepository.save(new User("new2@gist.ac.kr", "password", UserRole.USER));
+
+        agreePetitionBy(createdPetitionIds.get(0), List.of(user1));
+        agreePetitionBy(createdPetitionIds.get(1), List.of(user1, user2));
+
+        Page<PetitionPreviewResponse> petitions = petitionQueryDslDao.findAll(null, ONGOING.at(Instant.now()), PageRequest.of(0, 10, Sort.Direction.DESC, "agreeCount"));
+        assertThat(petitions.getContent()).hasSize(numOfPetition);
+        assertThat(petitions.getContent().stream().map(PetitionPreviewResponse::getId))
+                .containsExactly(createdPetitionIds.get(1), createdPetitionIds.get(0), createdPetitionIds.get(2));
+    }
+
+    @Test
+    void retrieveAnsweredPetition() {
+        int numOfPetition = 3;
+        List<Long> createdPetitionIds = new ArrayList<>();
+        for (int i = 0; i < numOfPetition; i++) {
+            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
+        }
+        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_ANSWER);
+        createdPetitionIds.forEach(i -> {
+            agreePetitionBy(i, users);
+            petitionCommandService.releasePetition(i);
+            petitionCommandService.answerPetition(i, ANSWER_REQUEST);
+        });
+
+        Page<PetitionPreviewResponse> petitions = petitionQueryDslDao.findAll(null, ANSWERED.at(Instant.now()), PageRequest.of(0, 10));
+        assertThat(petitions).hasSize(numOfPetition);
+    }
+
+    @Test
+    void retrievePetitionOfMine() {
+        int numOfPetition = 3;
+        for (int i = 0; i < numOfPetition; i++) {
+            petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
+        }
+
+        Page<PetitionPreviewResponse> petitions = petitionQueryDslDao.findAll(null, petition.userId.eq(petitionOwner.getId()), PageRequest.of(0, 10));
+        assertThat(petitions).hasSize(numOfPetition);
+    }
+
+    private List<User> saveUsersNumberOf(int numberOfUsers) {
+        List<User> users = LongStream.range(0, numberOfUsers)
+                .mapToObj(i -> new User(i + EMAIL, PASSWORD, UserRole.USER)).collect(Collectors.toList());
+        return userRepository.saveAll(users);
+    }
+
+    private void agreePetitionBy(Long petitionId, List<User> users) {
+        users.forEach(user -> petitionCommandService.agree(AGREEMENT_REQUEST, petitionId, user.getId()));
+    }
+}

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -3,7 +3,6 @@ package com.gistpetition.api.petition.application;
 import com.gistpetition.api.IntegrationTest;
 import com.gistpetition.api.exception.petition.DuplicatedAgreementException;
 import com.gistpetition.api.exception.petition.NoSuchPetitionException;
-import com.gistpetition.api.petition.PetitionBuilder;
 import com.gistpetition.api.petition.domain.*;
 import com.gistpetition.api.petition.domain.repository.*;
 import com.gistpetition.api.petition.dto.*;
@@ -316,18 +315,14 @@ class PetitionServiceTest extends IntegrationTest {
 
     @Test
     void deletePetition() {
-        Petition petition = petitionRepository.save(
-                PetitionBuilder.aPetition()
-                        .withExpiredAt(PETITION_EXPIRED_AT)
-                        .withUserId(petitionOwner.getId())
-                        .build());
-        agreeCountRepository.save(new AgreeCount(petition.getId()));
-        petitionCommandService.agree(AGREEMENT_REQUEST, petition.getId(), petitionOwner.getId());
+        Long petitionId = petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
 
-        petitionCommandService.deletePetition(petition.getId());
-        assertFalse(petitionRepository.existsById(petition.getId()));
+        petitionCommandService.agree(AGREEMENT_REQUEST, petitionId, petitionOwner.getId());
+
+        petitionCommandService.deletePetition(petitionId);
+        assertFalse(petitionRepository.existsById(petitionId));
         PageRequest pageRequest = PageRequest.of(0, 10);
-        assertThat(agreementRepository.findAgreementsByPetitionId(petition.getId(), pageRequest)).hasSize(0);
+        assertThat(agreementRepository.findAgreementsByPetitionId(petitionId, pageRequest)).hasSize(0);
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -398,7 +398,6 @@ class PetitionServiceTest extends IntegrationTest {
         Long petitionId = petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
         agreePetitionBy(petitionId, users);
-        petitionCommandService.releasePetition(petitionId);
 
         petitionCommandService.rejectPetition(petitionId, REJECTION_REQUEST);
 
@@ -413,7 +412,7 @@ class PetitionServiceTest extends IntegrationTest {
         Long petitionId = petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
         agreePetitionBy(petitionId, users);
-        petitionCommandService.releasePetition(petitionId);
+
         petitionCommandService.rejectPetition(petitionId, REJECTION_REQUEST);
 
         petitionCommandService.updateRejection(petitionId, UPDATE_REJECTION_REQUEST);
@@ -429,7 +428,6 @@ class PetitionServiceTest extends IntegrationTest {
         Long petitionId = petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
         List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
         agreePetitionBy(petitionId, users);
-        petitionCommandService.releasePetition(petitionId);
         petitionCommandService.rejectPetition(petitionId, REJECTION_REQUEST);
 
         petitionCommandService.cancelRejection(petitionId);

--- a/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
+++ b/src/test/java/com/gistpetition/api/petition/application/PetitionServiceTest.java
@@ -32,8 +32,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static com.gistpetition.api.petition.application.PetitionQueryCondition.ANSWERED;
+import static com.gistpetition.api.petition.application.PetitionQueryCondition.ONGOING;
 import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_ANSWER;
 import static com.gistpetition.api.petition.domain.Petition.REQUIRED_AGREEMENT_FOR_RELEASE;
+import static com.gistpetition.api.petition.domain.QPetition.petition;
 import static com.gistpetition.api.user.application.SessionLoginService.SESSION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,8 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 class PetitionServiceTest extends IntegrationTest {
-    public static final Instant PETITION_CREATION_AT = Instant.now();
-    public static final Instant PETITION_EXPIRED_AT = PETITION_CREATION_AT.plusSeconds(Petition.POSTING_PERIOD_BY_SECONDS);
     public static final AnswerRequest UPDATE_ANSWER_REQUEST = new AnswerRequest("답변 수정을 진행했다.");
     private static final PetitionRequest DORM_PETITION_REQUEST = new PetitionRequest("title", "description", Category.DORMITORY.getId());
     private static final AgreementRequest AGREEMENT_REQUEST = new AgreementRequest("동의합니다.");
@@ -228,77 +229,6 @@ class PetitionServiceTest extends IntegrationTest {
         Pageable pageableSizeAsTwo = PageRequest.of(0, 2, Sort.Direction.DESC, "createdAt");
         Page<AgreementResponse> twoOfAgreements = petitionQueryService.retrieveAgreements(petitionId, pageableSizeAsTwo);
         assertThat(twoOfAgreements).hasSize(2);
-    }
-
-    @Test
-    void retrieveOngoingPetition() {
-        int numOfPetition = 3;
-        List<Long> createdPetitionIds = new ArrayList<>();
-        for (int i = 0; i < numOfPetition; i++) {
-            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
-        }
-        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
-        createdPetitionIds.forEach(i -> {
-            agreePetitionBy(i, users);
-            petitionCommandService.releasePetition(i);
-        });
-
-        Page<PetitionPreviewResponse> petitions = petitionQueryService.retrieveOngoingPetition(PageRequest.of(0, 10));
-        assertThat(petitions.getContent()).hasSize(numOfPetition);
-    }
-
-    @Test
-    void retrieveOngoingPetitionWithAgreeCountSort() {
-        int numOfPetition = 3;
-        List<Long> createdPetitionIds = new ArrayList<>();
-        for (int i = 0; i < numOfPetition; i++) {
-            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
-        }
-        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_RELEASE);
-        createdPetitionIds.forEach(i -> {
-            agreePetitionBy(i, users);
-            petitionCommandService.releasePetition(i);
-        });
-
-        User user1 = userRepository.save(new User("new@gist.ac.kr", "password", UserRole.USER));
-        User user2 = userRepository.save(new User("new2@gist.ac.kr", "password", UserRole.USER));
-
-        agreePetitionBy(createdPetitionIds.get(0), List.of(user1));
-        agreePetitionBy(createdPetitionIds.get(1), List.of(user1, user2));
-
-        Page<PetitionPreviewResponse> petitions = petitionQueryService.retrieveOngoingPetition(PageRequest.of(0, 10, Sort.Direction.DESC, "agreeCount"));
-        assertThat(petitions.getContent()).hasSize(numOfPetition);
-        assertThat(petitions.getContent().stream().map(PetitionPreviewResponse::getId))
-                .containsExactly(createdPetitionIds.get(1), createdPetitionIds.get(0), createdPetitionIds.get(2));
-    }
-
-    @Test
-    void retrieveAnsweredPetition() {
-        int numOfPetition = 3;
-        List<Long> createdPetitionIds = new ArrayList<>();
-        for (int i = 0; i < numOfPetition; i++) {
-            createdPetitionIds.add(petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId()));
-        }
-        List<User> users = saveUsersNumberOf(REQUIRED_AGREEMENT_FOR_ANSWER);
-        createdPetitionIds.forEach(i -> {
-            agreePetitionBy(i, users);
-            petitionCommandService.releasePetition(i);
-            petitionCommandService.answerPetition(i, ANSWER_REQUEST);
-        });
-
-        Page<PetitionPreviewResponse> petitions = petitionQueryService.retrieveAnsweredPetition(PageRequest.of(0, 10));
-        assertThat(petitions).hasSize(numOfPetition);
-    }
-
-    @Test
-    void retrievePetitionOfMine() {
-        int numOfPetition = 3;
-        for (int i = 0; i < numOfPetition; i++) {
-            petitionCommandService.createPetition(DORM_PETITION_REQUEST, petitionOwner.getId());
-        }
-
-        Page<PetitionPreviewResponse> petitions = petitionQueryService.retrievePetitionsByUserId(petitionOwner.getId(), PageRequest.of(0, 10));
-        assertThat(petitions).hasSize(numOfPetition);
     }
 
     @Test

--- a/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
+++ b/src/test/java/com/gistpetition/api/petition/domain/PetitionTest.java
@@ -53,7 +53,7 @@ class PetitionTest {
     @MethodSource("create_petition_invalid_condition")
     void create_petition_invalid_condition(String title, String description, Class<Exception> exceptionClass) {
         assertThatThrownBy(
-                () -> new Petition(title, description, Category.DORMITORY, Instant.now(), 1L, "AAAAAA")
+                () -> new Petition(title, description, Category.DORMITORY, 1L)
         ).isInstanceOf(exceptionClass);
     }
 
@@ -128,7 +128,7 @@ class PetitionTest {
 
         assertThatThrownBy(
                 () -> petition.release(PETITION_NOT_EXPIRED_AT.plusSeconds(1))
-        ).isInstanceOf(AlreadyReleasedPetitionException.class);
+        ).isInstanceOf(NotValidStatusToReleasePetitionException.class);
     }
 
     @Test


### PR DESCRIPTION
close #339 
close #310 (QueryDsl 부분을 Dao로 분리하여 기존에 작성된 테스트를 별도로 분리를 진행했다. -> 두번 중복되어 작성되는 코드를 줄일 수 있었다.)

Flyway의 script를 활용하여 초기화를 진행

released의 상태를 삭제할 수 있지만, 이후에 프론트 처리가 완료되었을 때 같이 진행하도록 한다.